### PR TITLE
fix: make hash compatible with react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,10 @@
   },
   "dependencies": {
     "@digitalcredentials/jsonld-signatures": "^12.0.1",
+    "@noble/hashes": "^1.8.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "crypto": "^1.0.1",
+    "buffer": "^6.0.3",
     "did-resolver": "^4.1.0",
     "jsonld": "^8.3.3",
     "web-did-resolver": "^2.0.29"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,18 @@ importers:
       '@digitalcredentials/jsonld-signatures':
         specifier: ^12.0.1
         version: 12.0.1
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       did-resolver:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1361,6 +1364,10 @@ packages:
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1677,6 +1684,7 @@ packages:
 
   '@sphereon/kmp-mdl-mdoc@0.2.0-SNAPSHOT.22':
     resolution: {integrity: sha512-uAZZExVy+ug9JLircejWa5eLtAZ7bnBP6xb7DO2+86LRsHNLh2k2jMWJYxp+iWtGHTsh6RYsZl14ScQLvjiQ/A==}
+    bundledDependencies: []
 
   '@sphereon/pex-models@2.3.2':
     resolution: {integrity: sha512-foFxfLkRwcn/MOp/eht46Q7wsvpQGlO7aowowIIb5Tz9u97kYZ2kz6K2h2ODxWuv5CRA7Q0MY8XUBGE2lfOhOQ==}
@@ -2672,10 +2680,6 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
-
-  crypto@1.0.1:
-    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
-    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
 
   d@1.0.2:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
@@ -6861,7 +6865,7 @@ snapshots:
       '@digitalcredentials/vc': 6.0.1(expo@52.0.43(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(react@19.1.0))(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(react@19.1.0))(web-streams-polyfill@3.3.3)
       '@multiformats/base-x': 4.0.1
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@peculiar/asn1-ecc': 2.3.15
       '@peculiar/asn1-schema': 2.3.15
       '@peculiar/asn1-x509': 2.3.15
@@ -7733,6 +7737,8 @@ snapshots:
       '@noble/hashes': 1.7.1
 
   '@noble/hashes@1.7.1': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9510,8 +9516,6 @@ snapshots:
 
   crypto-random-string@2.0.0:
     optional: true
-
-  crypto@1.0.1: {}
 
   d@1.0.2:
     dependencies:

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,15 @@
+import { sha1 } from '@noble/hashes/legacy'
+import { sha256, sha384 } from '@noble/hashes/sha2'
+
+export function hash(algorithm: string, data: string) {
+  switch (algorithm.toUpperCase()) {
+    case 'SHA384':
+      return sha384(data)
+    case 'SHA256':
+      return sha256(data)
+    case 'SHA1':
+      return sha1(data)
+    default:
+      throw new Error(`Hash: '${algorithm}' is not supported.`)
+  }
+}

--- a/src/utils/verifier.ts
+++ b/src/utils/verifier.ts
@@ -1,10 +1,10 @@
-import type { W3cJsonLdVerifiableCredential, W3cJsonLdVerifiablePresentation } from '@credo-ts/core'
-
-import { createHash } from 'crypto'
+import { type W3cJsonLdVerifiableCredential, type W3cJsonLdVerifiablePresentation } from '@credo-ts/core'
+import { Buffer } from 'buffer/'
 
 import { purposes, suites, verify } from '../libraries'
 import { TrustErrorCode } from '../types'
 
+import { hash } from './crypto'
 import { TrustError } from './trustError'
 
 /**
@@ -113,9 +113,7 @@ const documentLoader = async (url: string): Promise<{ document: any }> => {
  */
 export function verifyDigestSRI(schemaJson: string, expectedDigestSRI: string, name: string) {
   const [algorithm, expectedHash] = expectedDigestSRI.split('-')
-  const computedHash = createHash(algorithm)
-    .update(JSON.stringify(JSON.parse(schemaJson)), 'utf8')
-    .digest('base64')
+  const computedHash = Buffer.from(hash(algorithm, JSON.stringify(JSON.parse(schemaJson)))).toString('base64')
 
   if (computedHash !== expectedHash) {
     throw new TrustError(TrustErrorCode.VERIFICATION_FAILED, `digestSRI verification failed for ${name}.`)


### PR DESCRIPTION
Remove dependency on `crypto`, since it is a module exclusively found in NodeJS environment and we need Verre to work also in React Native.

@noble/hashes was used as as direct replacement, for the moment supporting only sha1, sha256 and sha384 but easily extendable to support stronger hash algorithms if needed.