### PR TITLE
feat: update interface output structure and testing

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -162,7 +162,7 @@ async function processDidDocument(
           const credential = await getVerifiedCredential(vp, trustRegistryUrl, agentContext)
           credentials.push(credential)
 
-          const isServiceCred = credential.type === ECS.SERVICE
+          const isServiceCred = credential.schemaType === ECS.SERVICE
           const isExternalIssuer = credential.issuer !== did
 
           if (isServiceCred && isExternalIssuer) {
@@ -182,9 +182,9 @@ async function processDidDocument(
       }
     }),
   )
-  service ??= credentials.find((cred): cred is IService => cred.type === ECS.SERVICE)
+  service ??= credentials.find((cred): cred is IService => cred.schemaType === ECS.SERVICE)
   serviceProvider ??= credentials.find(
-    (cred): cred is IOrg | IPerson => cred.type === ECS.ORG || cred.type === ECS.PERSON,
+    (cred): cred is IOrg | IPerson => cred.schemaType === ECS.ORG || cred.schemaType === ECS.PERSON,
   )
 
   // If proof of trust exists, return the result with the service (issuer equals did)
@@ -393,6 +393,7 @@ async function processCredential(
       "Missing 'credentialSchema' or 'credentialSubject' in Verifiable Trust Credential.",
     )
   }
+  const id = credential.id as string
   const issuer = credential.issuer as string
 
   if (!['JsonSchemaCredential', 'JsonSchema'].includes(schema.type))
@@ -432,7 +433,7 @@ async function processCredential(
 
       // Validate the credential subject attributes against the JSON schema content
       validateSchemaContent(JSON.parse(subjectSchema.json_schema), attrs)
-      return { type: identifySchema(attrs), issuer, credentialSubject: attrs } as ICredential
+      return { schemaType: identifySchema(attrs), id, issuer, ...attrs } as ICredential
     } catch (error) {
       throw new TrustError(TrustErrorCode.INVALID, `Failed to validate credential: ${error.message}`)
     }

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -69,7 +69,7 @@ export async function resolve(did: string, options: ResolverConfig): Promise<Tru
  */
 export async function _resolve(did: string, options: InternalResolverConfig): Promise<TrustResolution> {
   if (!did) {
-    return { metadata: buildMetadata(TrustErrorCode.INVALID, 'Invalid DID URL') }
+    return { verified: false, metadata: buildMetadata(TrustErrorCode.INVALID, 'Invalid DID URL') }
   }
 
   const { trustRegistryUrl, didResolver, attrs, agentContext } = options
@@ -191,7 +191,7 @@ async function processDidDocument(
   if (issuerCredential && verifiableService) {
     return {
       didDocument,
-      metadata: buildMetadata(),
+      verified: true,
       issuerCredential,
       verifiableService,
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,70 +129,60 @@ export interface TrustResolutionMetadata {
 }
 
 export interface BaseCredential {
-  type: ECS | 'unknown'
+  schemaType: ECS | 'unknown'
+  id: string
   issuer: string
-  credentialSubject: Record<string, unknown>
 }
 
 export interface IOrg extends BaseCredential {
-  type: typeof ECS.ORG
-  credentialSubject: {
-    name: string
-    logo: string
-    registryId: string
-    registryUrl: string
-    address: string
-    type: string
-    countryCode: string
-  }
+  schemaType: typeof ECS.ORG
+  name: string
+  logo: string
+  registryId: string
+  registryUrl: string
+  address: string
+  type: string
+  countryCode: string
 }
 
 export interface IPerson extends BaseCredential {
-  type: typeof ECS.PERSON
-  credentialSubject: {
-    firstName: string
-    lastName: string
-    avatar: string
-    birthDate: string
-    countryOfResidence: string
-  }
+  schemaType: typeof ECS.PERSON
+  firstName: string
+  lastName: string
+  avatar: string
+  birthDate: string
+  countryOfResidence: string
 }
 
 export interface IService extends BaseCredential {
-  type: typeof ECS.SERVICE
-  credentialSubject: {
-    name: string
-    type: string
-    description: string
-    logo: string
-    minimumAgeRequired: number
-    termsAndConditions: string
-    termsAndConditionsHash?: string
-    privacyPolicy: string
-    privacyPolicyHash?: string
-  }
+  schemaType: typeof ECS.SERVICE
+  name: string
+  type: string
+  description: string
+  logo: string
+  minimumAgeRequired: number
+  termsAndConditions: string
+  termsAndConditionsHash?: string
+  privacyPolicy: string
+  privacyPolicyHash?: string
 }
 
 export interface IUserAgent extends BaseCredential {
-  type: typeof ECS.USER_AGENT
-  credentialSubject: {
-    name: string
-    description: string
-    category: string
-    wallet: string
-    logo: string
-    termsAndConditions: string
-    termsAndConditionsHash?: string
-    privacyPolicy: string
-    privacyPolicyHash?: string
-  }
+  schemaType: typeof ECS.USER_AGENT
+  name: string
+  description: string
+  category: string
+  wallet: string
+  logo: string
+  termsAndConditions: string
+  termsAndConditionsHash?: string
+  privacyPolicy: string
+  privacyPolicyHash?: string
 }
 
 export interface IUnknownCredential extends BaseCredential {
-  type: 'unknown'
-  credentialSubject: {
-    [key: string]: any
-  }
+  schemaType: 'unknown'
+  [key: string]: any
 }
 
 export type ICredential = IOrg | IPerson | IService | IUserAgent | IUnknownCredential

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,8 @@ export type TrustResolution = {
   didDocument?: DIDDocument
   verified: boolean
   metadata?: TrustResolutionMetadata
-  verifiableService?: IService
-  issuerCredential?: ICredential
+  service?: IService
+  serviceProvider?: ICredential
 }
 
 export type ResolverConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,8 @@ import { DIDDocument, Resolver, ServiceEndpoint } from 'did-resolver'
 // types
 export type TrustResolution = {
   didDocument?: DIDDocument
-  metadata: TrustResolutionMetadata
+  verified: boolean
+  metadata?: TrustResolutionMetadata
   verifiableService?: IService
   issuerCredential?: ICredential
 }
@@ -59,11 +60,6 @@ export enum VerifiablePresentationState {
   VALIDATED = 'VALIDATED',
   TERMINATED = 'TERMINATED',
   TERMINATION_REQUESTED = 'TERMINATION_REQUESTED',
-}
-
-export enum TrustStatus {
-  RESOLVED = 'resolved',
-  ERROR = 'error',
 }
 
 export enum TrustErrorCode {
@@ -129,7 +125,6 @@ export interface Permission {
 
 export interface TrustResolutionMetadata {
   errorMessage?: string
-  status: TrustStatus
   errorCode?: TrustErrorCode
 }
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,4 +1,4 @@
-import { TrustResolutionMetadata, TrustErrorCode, TrustStatus } from '../types'
+import { TrustResolutionMetadata, TrustErrorCode } from '../types'
 
 import { TrustError } from './trustError'
 
@@ -12,16 +12,8 @@ import { TrustError } from './trustError'
  * @param errorMessage - Optional descriptive error message.
  * @returns The metadata containing the resolution status and error details if applicable.
  */
-export function buildMetadata(errorCode?: TrustErrorCode, errorMessage?: string): TrustResolutionMetadata {
-  if (!errorCode) {
-    return {
-      status: TrustStatus.RESOLVED,
-      errorMessage,
-    }
-  }
-
+export function buildMetadata(errorCode: TrustErrorCode, errorMessage: string): TrustResolutionMetadata {
   return {
-    status: TrustStatus.ERROR,
     errorCode,
     errorMessage,
   }

--- a/src/utils/trustError.ts
+++ b/src/utils/trustError.ts
@@ -26,7 +26,11 @@ export class TrustError extends Error {
  */
 export function handleTrustError(error: unknown, didDocument?: DIDDocument) {
   if (error instanceof TrustError) {
-    return { didDocument, metadata: error.metadata }
+    return { didDocument, verified: false, metadata: error.metadata }
   }
-  return { didDocument, metadata: buildMetadata(TrustErrorCode.INVALID, `Unexpected error: ${error}`) }
+  return {
+    didDocument,
+    verified: false,
+    metadata: buildMetadata(TrustErrorCode.INVALID, `Unexpected error: ${error}`),
+  }
 }

--- a/tests/__mocks__/object.ts
+++ b/tests/__mocks__/object.ts
@@ -58,13 +58,13 @@ export const mockDidDocumentChatbot = {
       id: 'did:web:dm.chatbot.demos.dev.2060.io#verkey',
       type: 'Ed25519VerificationKey2018',
       controller: 'did:web:dm.chatbot.demos.dev.2060.io',
-      publicKeyBase58: '9wTuaMZVuyCPnhgf2nFQ74PvSchHYfxNgYMcoQZeM3tP',
+      publicKeyBase58: '3ujbdYy3xPaBU1wrqnu1uxvTwcC5mmV8x19QM7QBHyJA',
     },
     {
       id: 'did:web:dm.chatbot.demos.dev.2060.io#key-agreement-1',
       type: 'X25519KeyAgreementKey2019',
       controller: 'did:web:dm.chatbot.demos.dev.2060.io',
-      publicKeyBase58: 'GZD1vVkspnL4BYkHryttbJjkDpXP5sfQHtWp59iNjGGK',
+      publicKeyBase58: 'Eys7NKY6yQBm2mSTrgjyYRbvPkbGjru1SNLSPNZcghBH',
     },
   ],
   service: [

--- a/tests/__mocks__/object.ts
+++ b/tests/__mocks__/object.ts
@@ -58,13 +58,13 @@ export const mockDidDocumentChatbot = {
       id: 'did:web:dm.chatbot.demos.dev.2060.io#verkey',
       type: 'Ed25519VerificationKey2018',
       controller: 'did:web:dm.chatbot.demos.dev.2060.io',
-      publicKeyBase58: 'Fw7Yw9KD7fbF71Dp4ypCJEnuD64G3X1mnCEMdf8YLhpT',
+      publicKeyBase58: '9wTuaMZVuyCPnhgf2nFQ74PvSchHYfxNgYMcoQZeM3tP',
     },
     {
       id: 'did:web:dm.chatbot.demos.dev.2060.io#key-agreement-1',
       type: 'X25519KeyAgreementKey2019',
       controller: 'did:web:dm.chatbot.demos.dev.2060.io',
-      publicKeyBase58: 'CNVJ5UsXYiY61EndQis2TWNMyTcYNpxcfPyMoAXpAAtJ',
+      publicKeyBase58: 'GZD1vVkspnL4BYkHryttbJjkDpXP5sfQHtWp59iNjGGK',
     },
   ],
   service: [

--- a/tests/didValidator.test.ts
+++ b/tests/didValidator.test.ts
@@ -142,14 +142,16 @@ describe('DidValidator', () => {
           verified: true,
           ...mockDidDocumentSelfIssued,
           service: {
-            type: ECS.SERVICE,
+            schemaType: ECS.SERVICE,
+            id: didSelfIssued,
             issuer: didSelfIssued,
-            credentialSubject: mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
+            ...mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
           },
           serviceProvider: {
-            type: ECS.ORG,
+            schemaType: ECS.ORG,
+            id: didSelfIssued,
             issuer: didSelfIssued,
-            credentialSubject: mockOrgVc.verifiableCredential[0].credentialSubject,
+            ...mockOrgVc.verifiableCredential[0].credentialSubject,
           },
         }),
       )
@@ -218,14 +220,16 @@ describe('DidValidator', () => {
           verified: true,
           ...mockDidDocumentSelfIssuedExtIssuer,
           service: {
-            type: ECS.SERVICE,
+            schemaType: ECS.SERVICE,
+            id: didSelfIssued,
             issuer: didSelfIssued,
-            credentialSubject: mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            ...mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
           },
           serviceProvider: {
-            type: ECS.ORG,
+            schemaType: ECS.ORG,
+            id: didSelfIssued,
             issuer: didSelfIssued,
-            credentialSubject: mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            ...mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
           },
         }),
       )
@@ -298,14 +302,16 @@ describe('DidValidator', () => {
           verified: true,
           ...mockDidDocumentSelfIssuedExtIssuer,
           service: {
-            type: ECS.SERVICE,
+            schemaType: ECS.SERVICE,
+            id: didSelfIssued,
             issuer: didSelfIssued,
-            credentialSubject: mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            ...mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
           },
           serviceProvider: {
-            type: ECS.ORG,
+            schemaType: ECS.ORG,
+            id: didSelfIssued,
             issuer: didSelfIssued,
-            credentialSubject: mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            ...mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
           },
         }),
       )

--- a/tests/didValidator.test.ts
+++ b/tests/didValidator.test.ts
@@ -2,7 +2,7 @@ import { Agent, AgentContext, DidResolverService } from '@credo-ts/core'
 import { Resolver } from 'did-resolver'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-import { ECS, resolve, TrustErrorCode, TrustStatus } from '../src'
+import { ECS, resolve, TrustErrorCode } from '../src'
 import * as signatureVerifier from '../src/utils/verifier'
 
 import {
@@ -86,9 +86,8 @@ describe('DidValidator', () => {
       // Testing
       expect(resolveSpy).toHaveBeenCalledTimes(1)
       expect(resolveSpy).toHaveBeenCalledWith(did)
-      expect(result.metadata).toEqual(
-        expect.objectContaining({ status: TrustStatus.ERROR, errorCode: TrustErrorCode.NOT_FOUND }),
-      )
+      expect(result.verified).toEqual(false)
+      expect(result.metadata).toEqual(expect.objectContaining({ errorCode: TrustErrorCode.NOT_FOUND }))
       expect(result.didDocument).toEqual({ ...mockDidDocumentChatbot })
     })
 
@@ -140,14 +139,14 @@ describe('DidValidator', () => {
       expect(resolverInstanceSpy).toHaveBeenCalledTimes(1)
       expect(result).toEqual(
         expect.objectContaining({
-          metadata: { status: TrustStatus.RESOLVED },
+          verified: true,
           ...mockDidDocumentSelfIssued,
-          verifiableService: {
+          service: {
             type: ECS.SERVICE,
             issuer: didSelfIssued,
             credentialSubject: mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
           },
-          issuerCredential: {
+          serviceProvider: {
             type: ECS.ORG,
             issuer: didSelfIssued,
             credentialSubject: mockOrgVc.verifiableCredential[0].credentialSubject,
@@ -216,14 +215,14 @@ describe('DidValidator', () => {
       expect(resolverInstanceSpy).toHaveBeenCalledTimes(2)
       expect(result).toEqual(
         expect.objectContaining({
-          metadata: { status: TrustStatus.RESOLVED },
+          verified: true,
           ...mockDidDocumentSelfIssuedExtIssuer,
-          verifiableService: {
+          service: {
             type: ECS.SERVICE,
             issuer: didSelfIssued,
             credentialSubject: mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
           },
-          issuerCredential: {
+          serviceProvider: {
             type: ECS.ORG,
             issuer: didSelfIssued,
             credentialSubject: mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
@@ -296,14 +295,14 @@ describe('DidValidator', () => {
       expect(resolverInstanceSpy).toHaveBeenCalledTimes(2)
       expect(result).toEqual(
         expect.objectContaining({
-          metadata: { status: TrustStatus.RESOLVED },
+          verified: true,
           ...mockDidDocumentSelfIssuedExtIssuer,
-          verifiableService: {
+          service: {
             type: ECS.SERVICE,
             issuer: didSelfIssued,
             credentialSubject: mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
           },
-          issuerCredential: {
+          serviceProvider: {
             type: ECS.ORG,
             issuer: didSelfIssued,
             credentialSubject: mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,


### PR DESCRIPTION
Update the output model on Verre, the new structure is the following
```
verified: true,
didDocument: DidDocument,
service: {
  schemaType: 'ecs-service',
  id: (did),
  issuer: (did),
  ... attributes currently under 'credentialSubject'
},
serviceProvider: {
  schemaType: 'ecs-org',
  id: (did),
  issuer: (did),
  ... attributes currently under 'credentialSubject'
}
```