### PR TITLE
test: add helper to ignore dynamic fields in didDocument assertions

### DIFF
--- a/tests/__mocks__/helpers.ts
+++ b/tests/__mocks__/helpers.ts
@@ -1,0 +1,8 @@
+// Remove public keys from the DID document for testing purposes,
+// as they aren't the same across different did documents over real use cases.
+export function stripPublicKeys(didDocument: any) {
+  return {
+    ...didDocument,
+    verificationMethod: didDocument.verificationMethod.map(({ publicKeyBase58, ...rest }: any) => rest),
+  }
+}

--- a/tests/__mocks__/index.ts
+++ b/tests/__mocks__/index.ts
@@ -1,3 +1,4 @@
 export * from './agent'
 export * from './fetch'
+export * from './helpers'
 export * from './object'

--- a/tests/integration/network.test.ts
+++ b/tests/integration/network.test.ts
@@ -15,6 +15,7 @@ import {
   linkedVpOrg,
   linkedVpService,
   mockDidDocumentChatbot,
+  stripPublicKeys,
 } from '../__mocks__'
 
 /**
@@ -93,7 +94,9 @@ describe('Integration with Verana Blockchain', () => {
     expect(resolveSpy).toHaveBeenCalledTimes(1)
     expect(resolveSpy).toHaveBeenCalledWith(did)
     expect(result.verified).toEqual(true)
-    expect(JSON.parse(JSON.stringify(result.didDocument))).toEqual(mockDidDocumentChatbot)
+    expect(stripPublicKeys(JSON.parse(JSON.stringify(result.didDocument)))).toEqual(
+      stripPublicKeys(mockDidDocumentChatbot),
+    )
   }, 10000)
 
   it('should integrate with Verana testnet and retrieve the nested schema from the blockchain', async () => {


### PR DESCRIPTION
This PR adds a helper function to remove dynamic fields (such as `publicKeyBase58`) from the `didDocument` object when performing test assertions.