### PR TITLE
feat: include adapter to verifiablepublicregistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The main entry point for using the resolver is the `resolve` function, which all
 1. [Parameters](#parameters)
 1. [Return Value](#return-value)
 1. [Usage Example](#usage-example)
+1. [Registry Adapter — embedded use](#registry-adapter--embedded-use)
 1. [Notes](#notes)
 
 ---
@@ -232,6 +233,77 @@ const result = await resolveDID('did:web:example.com', {
 })
 console.log('Resolved DID Document:', result)
 ```
+
+## Registry Adapter — embedded use
+
+By default, verre resolves permissions and schemas by making HTTP calls to the registry's
+API and indexer endpoints. This works well when verre is used as an external client.
+
+However, if your service **is itself the registry** (e.g. a trust-registry backend or
+indexer that also needs to validate incoming DIDs or credentials), those HTTP calls would
+loop back into the same process — adding unnecessary network latency and a dependency on
+the network stack.
+
+For this case, each `VerifiablePublicRegistry` entry accepts an optional `adapter` field
+that implements `IRegistryAdapter`. When verre encounters a credential referencing that
+registry, it calls the adapter's methods directly instead of making any HTTP request.
+
+### Interface
+
+```ts
+interface IRegistryAdapter {
+  // Returns the raw JSON text of the subject schema by its resolved URL.
+  fetchSchema(url: string): Promise<string>
+
+  // Returns the permission record for a DID, or undefined if none exists.
+  // verre handles date-range validation (effective_from / effective_until) after this call.
+  fetchPermission(
+    schemaId: string,
+    did: string,
+    permissionType: PermissionType,
+  ): Promise<
+    Pick<Permission, 'type' | 'created' | 'effective_from' | 'effective_until'> | undefined
+  >
+}
+```
+
+### Example
+
+```ts
+import { resolveDID, IRegistryAdapter, VerifiablePublicRegistry, PermissionType } from '@verana-labs/verre'
+
+class RegistryAdapter implements IRegistryAdapter {
+  constructor(
+    private schemaService: SchemaService,
+    private permissionService: PermissionService,
+  ) {}
+
+  async fetchSchema(url: string): Promise<string> {
+    // Direct in-process lookup — no HTTP
+    return this.schemaService.getJsonByUrl(url)
+  }
+
+  async fetchPermission(schemaId: string, did: string, permissionType: PermissionType) {
+    // Direct in-process lookup — no HTTP
+    return this.permissionService.findFirst({ schemaId, did, type: permissionType })
+  }
+}
+
+const registries: VerifiablePublicRegistry[] = [
+  {
+    id: 'https://registry.example.com/vpr',
+    baseUrls: ['https://registry.example.com/vpr'],
+    production: true,
+    adapter: new RegistryAdapter(schemaService, permissionService),
+  },
+]
+
+const result = await resolveDID(did, { verifiablePublicRegistries: registries })
+```
+
+When `adapter` is omitted, verre falls back to standard HTTP resolution as usual.
+
+---
 
 ## Notes
 - The method supports ECS (Entity Credential Schema) identifiers such as `ORG`, `PERSON`, `USER-AGENT`, and `SERVICE`.

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -10,6 +10,7 @@ import { DIDDocument, Resolver, Service } from 'did-resolver'
 import { resolverInstance } from '../libraries/index.js'
 import {
   ECS,
+  IRegistryAdapter,
   ResolverConfig,
   TrustResolution,
   TrustErrorCode,
@@ -86,8 +87,11 @@ export async function verifyPermissions(options: VerifyPermissionsOptions) {
     logger.debug('Verifying permissions', { permissionType })
     const credential = await fetchJson<W3cVerifiableCredential>(jsonSchemaCredentialId)
     const { subject } = resolveSchemaAndSubject(credential, logger)
-    const { trustRegistry, schemaId } = resolveTrustRegistry(getRefUrl(subject), verifiablePublicRegistries)
-    await verifyPermission(trustRegistry, schemaId, issuanceDate, did, permissionType, logger)
+    const { trustRegistry, schemaId, adapter } = resolveTrustRegistry(
+      getRefUrl(subject),
+      verifiablePublicRegistries,
+    )
+    await verifyPermission(trustRegistry, schemaId, issuanceDate, did, permissionType, logger, adapter)
     logger.debug('Issuer permissions verified successfully')
     return { verified: true }
   } catch (error) {
@@ -140,7 +144,13 @@ export async function resolveCredential(
 function resolveTrustRegistry(
   refUrl: string,
   verifiablePublicRegistries?: VerifiablePublicRegistry[],
-): { trustRegistry: string; schemaId: string; outcome: TrustResolutionOutcome; schemaUrl: string } {
+): {
+  trustRegistry: string
+  schemaId: string
+  outcome: TrustResolutionOutcome
+  schemaUrl: string
+  adapter?: IRegistryAdapter
+} {
   const registry = verifiablePublicRegistries?.find(registry => refUrl.startsWith(registry.id))
   const schemaUrl =
     registry?.id && registry.id[0] ? refUrl.replace(registry.id, registry.baseUrls[0]) : refUrl
@@ -157,6 +167,7 @@ function resolveTrustRegistry(
     schemaId: segments.at(-1)!,
     outcome,
     schemaUrl,
+    adapter: registry?.adapter,
   }
 }
 
@@ -457,11 +468,11 @@ async function processCredential(
     try {
       // Extract the reference URL from the subject if it contains a JSON Schema reference
       const refUrl = getRefUrl(subject)
-      const { trustRegistry, schemaId, outcome, schemaUrl } = resolveTrustRegistry(
+      const { trustRegistry, schemaId, outcome, schemaUrl, adapter } = resolveTrustRegistry(
         refUrl,
         verifiablePublicRegistries,
       )
-      logger.debug('Trust registry resolved', { trustRegistry, schemaId, outcome })
+      logger.debug('Trust registry resolved', { trustRegistry, schemaId, outcome, hasAdapter: !!adapter })
 
       if (!issuer || !issuanceDate)
         throw new TrustError(
@@ -473,8 +484,16 @@ async function processCredential(
       logger.debug('Fetching schemas and verifying permission in parallel')
       const [schemaRawText, subjectSchemaRawText] = await Promise.all([
         fetchText(schema.id),
-        fetchText(schemaUrl),
-        verifyPermission(trustRegistry, schemaId, issuanceDate, issuer, PermissionType.ISSUER, logger),
+        adapter ? adapter.fetchSchema(schemaUrl) : fetchText(schemaUrl),
+        verifyPermission(
+          trustRegistry,
+          schemaId,
+          issuanceDate,
+          issuer,
+          PermissionType.ISSUER,
+          logger,
+          adapter,
+        ),
       ])
 
       const schemaData = JSON.parse(schemaRawText)
@@ -578,15 +597,26 @@ async function verifyPermission(
   did: string,
   permissionType: PermissionType,
   logger: IVerreLogger,
+  adapter?: IRegistryAdapter,
 ) {
-  logger.debug('Verifying permission', { schemaId, did })
-  const permUrl = `${toIndexerUrl(trustRegistry)}/perm/v1/list?did=${encodeURIComponent(
-    did,
-  )}&type=${permissionType}&response_max_size=1&schema_id=${schemaId}`
+  logger.debug('Verifying permission', { schemaId, did, hasAdapter: !!adapter })
 
-  logger.debug('Fetching issuer permissions', { permUrl, schemaId })
-  const permResponse = await fetchJson<PermissionResponse>(permUrl)
-  const perm = permResponse.permissions?.[0]
+  let perm:
+    | { type: string; created: string; effective_from?: string | null; effective_until?: string | null }
+    | undefined
+
+  if (adapter) {
+    logger.debug('Using registry adapter for permission check', { schemaId, did })
+    perm = await adapter.fetchPermission(schemaId, did, permissionType)
+  } else {
+    const permUrl = `${toIndexerUrl(trustRegistry)}/perm/v1/list?did=${encodeURIComponent(
+      did,
+    )}&type=${permissionType}&response_max_size=1&schema_id=${schemaId}`
+    logger.debug('Fetching issuer permissions', { permUrl, schemaId })
+    const permResponse = await fetchJson<PermissionResponse>(permUrl)
+    perm = permResponse.permissions?.[0]
+  }
+
   if (!perm || perm.type !== permissionType)
     throw new TrustError(
       TrustErrorCode.INVALID_PERMISSIONS,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,10 +38,31 @@ export type InternalResolverConfig = Omit<ResolverConfig, 'didResolver'> & {
   attrs?: IService
 }
 
+/**
+ * Adapter interface for resolving registry operations locally, without making HTTP calls.
+ * Intended for use when verre runs inside the same process as the registry (e.g., the indexer).
+ */
+export interface IRegistryAdapter {
+  /**
+   * Fetches a schema by URL. Replaces the HTTP fetchText call for the subject schema.
+   */
+  fetchSchema(url: string): Promise<string>
+  /**
+   * Fetches the permission for a given DID and schema. Replaces the HTTP call to /perm/v1/list.
+   * Return undefined if no permission exists (verre will throw INVALID_PERMISSIONS).
+   */
+  fetchPermission(
+    schemaId: string,
+    did: string,
+    permissionType: PermissionType,
+  ): Promise<Pick<Permission, 'type' | 'created' | 'effective_from' | 'effective_until'> | undefined>
+}
+
 export type VerifiablePublicRegistry = {
   id: string
   baseUrls: string[]
   production: boolean
+  adapter?: IRegistryAdapter
 }
 
 export type DidDocumentResult = {

--- a/tests/__mocks__/object.ts
+++ b/tests/__mocks__/object.ts
@@ -1,6 +1,6 @@
 // __mocks__/didMocks.ts
 
-import { ECS, VerifiablePublicRegistry } from '../../src'
+import { ECS, IRegistryAdapter, VerifiablePublicRegistry } from '../../src'
 
 import { essentialSchemas } from './data'
 
@@ -337,6 +337,17 @@ export const verifiablePublicRegistries: VerifiablePublicRegistry[] = [
     production: false,
   },
 ]
+
+export function createRegistriesWithAdapter(adapter: IRegistryAdapter): VerifiablePublicRegistry[] {
+  return [
+    {
+      id: 'https://vpr-hostname/vpr',
+      baseUrls: ['https://testTrust.com'],
+      production: true,
+      adapter,
+    },
+  ]
+}
 
 // Mock integration didDocument
 export const integrationDidDoc = JSON.parse(

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -1,10 +1,11 @@
 import { Resolver } from 'did-resolver'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-import { ECS, resolveDID, TrustResolutionOutcome } from '../../src'
+import { ECS, IVerreLogger, PermissionType, resolveDID, TrustResolutionOutcome } from '../../src'
 import { resolverInstance } from '../../src/libraries'
 import * as signatureVerifier from '../../src/utils/verifier'
 import {
+  createRegistriesWithAdapter,
   didExtIssuer,
   didSelfIssued,
   fetchMocker,
@@ -297,6 +298,88 @@ describe('DidValidator', () => {
         skipDigestSRICheck: true,
       })
       expect(verifyDigestSRISpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('registry adapter', () => {
+    beforeEach(() => {
+      vi.spyOn(signatureVerifier, 'verifySignature').mockResolvedValue({ result: true })
+      fetchMocker.enable()
+    })
+
+    afterEach(() => {
+      fetchMocker.reset()
+      fetchMocker.disable()
+      vi.clearAllMocks()
+      resolverInstance.clear()
+    })
+
+    it('should call adapter methods instead of HTTP for schema and permission', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+
+      const mockLogger: IVerreLogger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      }
+
+      const fetchSchemaSpy = vi.fn(async (url: string) => {
+        if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
+        if (url.includes('12345671')) return JSON.stringify(mockCredentialSchemaOrg)
+        throw new Error(`Unexpected schema URL in adapter: ${url}`)
+      })
+
+      const fetchPermissionSpy = vi.fn(async () => ({
+        type: PermissionType.ISSUER,
+        created: '2000-11-18T15:26:01.487Z',
+      }))
+
+      const registriesWithAdapter = createRegistriesWithAdapter({
+        fetchSchema: fetchSchemaSpy,
+        fetchPermission: fetchPermissionSpy,
+      })
+
+      fetchMocker.setMockResponses({
+        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+        'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+        'https://ecs-trust-registry/service-credential-schema-credential.json': {
+          ok: true,
+          status: 200,
+          data: mockServiceSchemaSelfIssued,
+        },
+        'https://ecs-trust-registry/org-credential-schema-credential.json': {
+          ok: true,
+          status: 200,
+          data: mockOrgSchema,
+        },
+        'https://www.w3.org/ns/credentials/json-schema/v2.json': {
+          ok: true,
+          status: 200,
+          data: mockW3cJsonSchemaV2,
+        },
+      })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithAdapter,
+        skipDigestSRICheck: true,
+        logger: mockLogger,
+      })
+
+      expect(result.verified).toBe(true)
+      expect(result.outcome).toBe(TrustResolutionOutcome.VERIFIED)
+
+      // Adapter methods were invoked — no HTTP to the indexer
+      expect(fetchSchemaSpy).toHaveBeenCalled()
+      expect(fetchPermissionSpy).toHaveBeenCalled()
+
+      // Logger confirms the adapter path was taken
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Using registry adapter for permission check',
+        expect.objectContaining({ schemaId: expect.any(String), did: didSelfIssued }),
+      )
     })
   })
 


### PR DESCRIPTION
**Changes:**
Add a new adapter interface to map the indexer resolution.
Implement it for use in the indexer or when the data to be validated is already available within the service.