### PR TITLE
feat: per-VP outcome accumulator + spec v4 fragment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ Resolves to a `TrustResolution` containing:
 * **metadata** (*TrustResolutionMetadata*, optional): Error or diagnostic information.
 * **service** (*IService*, optional): Verified DID service.
 * **serviceProvider** (*ICredential*, optional): Credential representing the trust provider.
+* **validPresentations** (*VpOutcome[]*, optional): Per-VP outcome accumulator. One entry per `LinkedVerifiablePresentation` service whose underlying VP yielded at least one valid credential. Each entry lists the credential ids that passed validation.
+* **invalidPresentations** (*VpOutcomeWithError[]*, optional): Per-VP / per-credential failure accumulator. May contain entries for VPs that failed at the dereference / signature stage as well as credential-level failures grouped by `errorCode`. A multi-credential VP can appear in BOTH arrays simultaneously when some credentials pass and others fail.
+
+#### Spec v4 fragment-suffix support
+
+`resolveDID` accepts the spec v4 fragment suffixes alongside the legacy v3
+suffix to ease migration:
+
+* **VTC presentations** — `-vtc-vp` (v4) **or** `-c-vp` (v3 legacy).
+* **VTJSC presentations** — `-vtjsc-vp` (v4 long form) **or** `-jsc-vp` (v4 short form).
+* **Both `vpr-schemas-*` and `vpr-ecs-*` namespaces** are recognised (the v4 spec renames trust registries to "ECS Trust Registry").
+
+Service entries whose fragment starts with `vpr-schemas`/`vpr-ecs` but matches no known suffix are surfaced under `invalidPresentations` with the `FRAGMENT_NOT_CONFORMANT` error code; unrelated `LinkedVerifiablePresentation` services are silently ignored.
 
 ---
 

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -27,6 +27,9 @@ import {
   PermissionType,
   LogLevel,
   IVerreLogger,
+  PresentationType,
+  VpOutcome,
+  VpOutcomeWithError,
 } from '../types.js'
 import {
   fetchJson,
@@ -39,6 +42,158 @@ import {
   verifySignature,
   VerreLogger,
 } from '../utils/index.js'
+
+/**
+ * Linked Verifiable Presentation fragment patterns.
+ *
+ * The fragment portion of a `LinkedVerifiablePresentation` service id encodes
+ * both its target schema family (`vpr-schemas` or `vpr-ecs`) and its
+ * presentation type (Verifiable Trust Credential vs. Verifiable Trust JSON
+ * Schema Credential).
+ *
+ * Verre supports both the legacy spec v3 suffixes (`-c-vp`, `-jsc-vp`) and
+ * the spec v4 suffixes (`-vtc-vp`, `-vtjsc-vp`) so that DID Documents
+ * conforming to either version remain resolvable. New deployments should
+ * emit v4 suffixes.
+ */
+const LINKED_VP_FRAGMENT_PATTERNS: { regex: RegExp; type: PresentationType; legacy: boolean }[] = [
+  // Verifiable Trust Credential
+  { regex: /^vpr-(schemas|ecs).*-c-vp$/, type: PresentationType.VTC, legacy: true },
+  { regex: /^vpr-(schemas|ecs).*-vtc-vp$/, type: PresentationType.VTC, legacy: false },
+  // Verifiable Trust JSON Schema Credential
+  { regex: /^vpr-(schemas|ecs).*-jsc-vp$/, type: PresentationType.VTJSC, legacy: true },
+  { regex: /^vpr-(schemas|ecs).*-vtjsc-vp$/, type: PresentationType.VTJSC, legacy: false },
+]
+
+/**
+ * Classify the fragment of a DID service id as a known linked-vp variant.
+ *
+ * @param serviceId - The full service id (`<did>#<fragment>`).
+ * @returns The presentation type when the fragment matches a known pattern,
+ *          otherwise `null`.
+ */
+function classifyVpFragment(serviceId: string): { presentationType: PresentationType } | null {
+  const fragment = serviceId.split('#')[1]
+  if (!fragment) return null
+  for (const { regex, type } of LINKED_VP_FRAGMENT_PATTERNS) {
+    if (regex.test(fragment)) return { presentationType: type }
+  }
+  return null
+}
+
+/**
+ * Heuristic check for service ids that *appear* to be linked-vp entries
+ * but use an unrecognised fragment suffix. Used to decide whether to emit
+ * `FRAGMENT_NOT_CONFORMANT` (recognisably-bad) versus silently skipping
+ * unrelated services (e.g. `did-communication`).
+ */
+function looksLikeLinkedVpFragment(serviceId: string): boolean {
+  const fragment = serviceId.split('#')[1]
+  return Boolean(fragment && /^vpr-(schemas|ecs)/.test(fragment))
+}
+
+/**
+ * Where in the resolution pipeline a coarse `TrustError` was raised.
+ * Used by `mapToFineGrainedCode` to translate legacy codes emitted by
+ * existing throw sites into the new fine-grained codes that populate
+ * `TrustResolution.invalidPresentations`.
+ */
+type ErrorContext =
+  | 'fragment'
+  | 'vp-fetch'
+  | 'vp-format'
+  | 'vp-signature'
+  | 'cred-format'
+  | 'cred-schema-ref'
+  | 'cred-schema-fetch'
+  | 'cred-schema-validate'
+  | 'cred-digest'
+  | 'cred-permission'
+  | 'cred-whitelist'
+  | 'cred-registry'
+  | 'cred-other'
+
+/**
+ * Translate a coarse `TrustErrorCode` thrown from a legacy code path into
+ * the fine-grained code appropriate for the calling context.
+ *
+ * Existing throw sites continue to use the legacy codes so that the public
+ * `metadata.errorCode` and `handleTrustError` behaviour is unchanged.
+ * The fine-grained codes are surfaced only on the new
+ * `invalidPresentations` array, which downstream consumers (such as the
+ * verana-resolver) can opt into.
+ */
+function mapToFineGrainedCode(coarse: TrustErrorCode, context: ErrorContext): TrustErrorCode {
+  // Codes already specific are returned as-is so that explicit throws of
+  // fine-grained codes (e.g. ECS_TRUST_REGISTRY_NOT_WHITELISTED) survive
+  // unchanged.
+  switch (coarse) {
+    case TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED:
+    case TrustErrorCode.REGISTRY_NOT_CONFIGURED:
+    case TrustErrorCode.FRAGMENT_NOT_CONFORMANT:
+    case TrustErrorCode.DEREFERENCE_FAILED:
+    case TrustErrorCode.VP_INVALID_FORMAT:
+    case TrustErrorCode.VP_SIGNATURE_INVALID:
+    case TrustErrorCode.VP_HOLDER_MISMATCH:
+    case TrustErrorCode.VP_NO_CREDENTIALS:
+    case TrustErrorCode.CREDENTIAL_SIGNATURE_INVALID:
+    case TrustErrorCode.CREDENTIAL_INVALID_FORMAT:
+    case TrustErrorCode.SCHEMA_NOT_FOUND:
+    case TrustErrorCode.CREDENTIAL_SCHEMA_MISMATCH:
+    case TrustErrorCode.SCHEMA_DIGEST_MISMATCH:
+    case TrustErrorCode.ISSUER_PERMISSION_MISSING:
+    case TrustErrorCode.ISSUER_PERMISSION_NOT_EFFECTIVE:
+      return coarse
+  }
+
+  switch (context) {
+    case 'fragment':
+      return TrustErrorCode.FRAGMENT_NOT_CONFORMANT
+    case 'vp-fetch':
+      return TrustErrorCode.DEREFERENCE_FAILED
+    case 'vp-format':
+      // NOT_FOUND from `getCredentials` (no creds) vs INVALID (bad VC type)
+      return coarse === TrustErrorCode.NOT_FOUND
+        ? TrustErrorCode.VP_NO_CREDENTIALS
+        : TrustErrorCode.VP_INVALID_FORMAT
+    case 'vp-signature':
+      return TrustErrorCode.VP_SIGNATURE_INVALID
+    case 'cred-format':
+      return TrustErrorCode.CREDENTIAL_INVALID_FORMAT
+    case 'cred-schema-ref':
+      return TrustErrorCode.CREDENTIAL_INVALID_FORMAT
+    case 'cred-schema-fetch':
+      return TrustErrorCode.SCHEMA_NOT_FOUND
+    case 'cred-schema-validate':
+      return TrustErrorCode.CREDENTIAL_SCHEMA_MISMATCH
+    case 'cred-digest':
+      return TrustErrorCode.SCHEMA_DIGEST_MISMATCH
+    case 'cred-permission':
+      // INVALID_PERMISSIONS may carry either MISSING or NOT_EFFECTIVE; use
+      // message heuristics to disambiguate (kept pragmatic since the legacy
+      // throw uses the same code for both subcases).
+      return TrustErrorCode.ISSUER_PERMISSION_MISSING
+    case 'cred-whitelist':
+      return TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED
+    case 'cred-registry':
+      return TrustErrorCode.REGISTRY_NOT_CONFIGURED
+    case 'cred-other':
+    default:
+      return coarse
+  }
+}
+
+/**
+ * Refine a fine-grained code based on the inner error message. Keeps the
+ * mapping conservative: only used when the coarse code is `INVALID_PERMISSIONS`
+ * and we can distinguish "no permission" from "issuance out of range".
+ */
+function refinePermissionCode(message: string | undefined): TrustErrorCode {
+  if (!message) return TrustErrorCode.ISSUER_PERMISSION_MISSING
+  return /effective range|effective_from|effective_until|issuance date/i.test(message)
+    ? TrustErrorCode.ISSUER_PERMISSION_NOT_EFFECTIVE
+    : TrustErrorCode.ISSUER_PERMISSION_MISSING
+}
 
 /**
  * Resolves a Decentralized Identifier (DID) and performs trust validation.
@@ -150,6 +305,13 @@ function resolveTrustRegistry(
   outcome: TrustResolutionOutcome
   schemaUrl: string
   adapter?: IRegistryAdapter
+  /**
+   * The matched registry entry, or `undefined` if `refUrl` does not start with
+   * any configured registry id. Exposed so that callers can apply
+   * registry-scoped policies (e.g. `allowedEcsEcosystems`) without re-running
+   * the prefix match.
+   */
+  registry?: VerifiablePublicRegistry
 } {
   const registry = verifiablePublicRegistries?.find(registry => refUrl.startsWith(registry.id))
   const schemaUrl =
@@ -168,6 +330,7 @@ function resolveTrustRegistry(
     outcome,
     schemaUrl,
     adapter: registry?.adapter,
+    registry,
   }
 }
 
@@ -251,61 +414,156 @@ async function processDidDocument(
   const { verifiablePublicRegistries, didResolver, attrs, skipDigestSRICheck } = options
 
   const credentials: ICredential[] = []
+  const validPresentations: VpOutcome[] = []
+  const invalidPresentations: VpOutcomeWithError[] = []
   let serviceProvider: ICredential | undefined
   let service: IService | undefined = attrs
   let outcome: TrustResolutionOutcome = TrustResolutionOutcome.NOT_TRUSTED
-  const patterns = [/^vpr-schemas.*-c-vp$/, /^vpr-ecs.*-c-vp$/]
 
   logger.debug('Processing DID services', { serviceCount: didDocument.service.length })
-  await Promise.all(
+
+  // Process every linked-vp service entry independently. We use
+  // `Promise.allSettled` so that a failure in any single VP does not
+  // abort processing of its siblings — this is what enables the
+  // per-VP `validPresentations` / `invalidPresentations` accumulator
+  // pattern. Per-VP outcomes (and any per-credential outcomes inside a
+  // VP) are pushed to the appropriate array and an aggregate outcome is
+  // tracked for the legacy `outcome` field (best of all valid VPs).
+  await Promise.allSettled(
     didDocument.service.map(async didService => {
       const { type, id } = didService
-      const matchesPattern = patterns.some(pattern => pattern.test(id.split('#')[1]))
-      logger.debug('Evaluating DID service', { id, type, matchesPattern })
-      if (type === 'LinkedVerifiablePresentation' && matchesPattern) {
-        logger.debug('Resolving linked VP service', { id })
-        const vp = await resolveServiceVP(didService)
-        if (!vp)
-          throw new TrustError(
-            TrustErrorCode.NOT_SUPPORTED,
-            `Invalid Linked Verifiable Presentation for service id: '${id}'`,
-          )
+      // Only LinkedVerifiablePresentation entries are in scope.
+      if (type !== 'LinkedVerifiablePresentation') {
+        logger.debug('Skipping non-linked-vp service', { id, type })
+        return
+      }
 
-        logger.debug('Getting verified credential from VP', { id })
-        const { credential, outcome: vpOutcome } = await getVerifiedCredential(
-          vp,
-          verifiablePublicRegistries ?? [],
-          logger,
-          didResolver,
-          skipDigestSRICheck,
-        )
-        credentials.push(credential)
-        outcome = vpOutcome
-
-        const isServiceCred = credential.schemaType === ECS.SERVICE
-        const isExternalIssuer = credential.issuer !== did
-
-        if (isServiceCred && isExternalIssuer) {
-          logger.debug('Processing external issuer service credential', { issuer: credential.issuer })
-          const resolution = await _resolve(credential.issuer, {
-            verifiablePublicRegistries,
-            didResolver,
-            attrs: credential,
-            skipDigestSRICheck,
-            cache: options.cache,
+      const classification = classifyVpFragment(id)
+      if (!classification) {
+        // Emit FRAGMENT_NOT_CONFORMANT only when the fragment looks like a
+        // linked-vp entry (starts with `vpr-schemas` or `vpr-ecs`); silently
+        // skip unrelated linked-vp services that happen to point elsewhere.
+        if (looksLikeLinkedVpFragment(id)) {
+          invalidPresentations.push({
+            serviceId: id,
+            vpUrl: id,
+            credentialIds: [],
+            errorCode: TrustErrorCode.FRAGMENT_NOT_CONFORMANT,
+            errorMessage: `Linked-vp fragment '${id.split('#')[1]}' does not match any known suffix (-c-vp / -vtc-vp / -jsc-vp / -vtjsc-vp)`,
           })
-          service = resolution.service
-          serviceProvider = resolution.serviceProvider
         }
+        return
+      }
+
+      const presentationType = classification.presentationType
+      logger.debug('Evaluating DID service', { id, type, presentationType })
+
+      const ctx = {
+        did,
+        serviceId: id,
+        presentationType,
+        verifiablePublicRegistries: verifiablePublicRegistries ?? [],
+        didResolver,
+        skipDigestSRICheck,
+        logger,
+        cache: options.cache,
+      }
+
+      const vpResult = await processLinkedVp(didService, ctx)
+
+      // Per-VP outcome bookkeeping.
+      if (vpResult.kind === 'vp-failed') {
+        invalidPresentations.push({
+          serviceId: id,
+          vpUrl: vpResult.vpUrl ?? id,
+          presentationType,
+          credentialIds: [],
+          errorCode: vpResult.errorCode,
+          errorMessage: vpResult.errorMessage,
+        })
+        return
+      }
+
+      // Per-credential outcome bookkeeping. A multi-credential VP may
+      // appear in BOTH arrays — its passing credentials in
+      // `validPresentations`, its failing credentials in
+      // `invalidPresentations` (grouped by error code).
+      if (vpResult.validCredentials.length > 0) {
+        validPresentations.push({
+          serviceId: id,
+          vpUrl: vpResult.vpUrl,
+          presentationType,
+          credentialIds: vpResult.validCredentials.map(c => c.credentialId),
+        })
+
+        for (const valid of vpResult.validCredentials) {
+          credentials.push(valid.credential)
+          if (valid.outcome > outcome) outcome = valid.outcome // upgrade best outcome
+        }
+      }
+
+      // Group failing credentials by error code so consumers can see
+      // exactly which credentials broke each rule.
+      const failuresByCode = new Map<TrustErrorCode, { ids: string[]; message: string }>()
+      for (const failed of vpResult.invalidCredentials) {
+        const slot = failuresByCode.get(failed.errorCode)
+        if (slot) {
+          slot.ids.push(failed.credentialId)
+        } else {
+          failuresByCode.set(failed.errorCode, {
+            ids: [failed.credentialId],
+            message: failed.errorMessage,
+          })
+        }
+      }
+      for (const [code, { ids, message }] of failuresByCode.entries()) {
+        invalidPresentations.push({
+          serviceId: id,
+          vpUrl: vpResult.vpUrl,
+          presentationType,
+          credentialIds: ids,
+          errorCode: code,
+          errorMessage: message,
+        })
+      }
+
+      // Indirect resolution: when the SERVICE credential is issued by a
+      // DID different from the one being resolved, recurse into the
+      // issuer's DID Document so that its `serviceProvider` (org/persona)
+      // attaches to the current trust resolution. Same semantics as the
+      // legacy implementation, only invoked once per VP from the first
+      // valid SERVICE credential found.
+      const externalServiceCred = vpResult.validCredentials.find(
+        (c): c is { credentialId: string; credential: IService; outcome: TrustResolutionOutcome } =>
+          c.credential.schemaType === ECS.SERVICE && c.credential.issuer !== did,
+      )?.credential
+      if (externalServiceCred) {
+        logger.debug('Processing external issuer service credential', {
+          issuer: externalServiceCred.issuer,
+        })
+        const resolution = await _resolve(externalServiceCred.issuer, {
+          verifiablePublicRegistries,
+          didResolver,
+          attrs: externalServiceCred,
+          skipDigestSRICheck,
+          cache: options.cache,
+        })
+        service = resolution.service
+        serviceProvider = resolution.serviceProvider
       }
     }),
   )
+
   service ??= credentials.find((cred): cred is IService => cred.schemaType === ECS.SERVICE)
   serviceProvider ??= credentials.find(
     (cred): cred is IOrg | IPersona => cred.schemaType === ECS.ORG || cred.schemaType === ECS.PERSONA,
   )
 
-  // If proof of trust exists, return the result with the service (issuer equals did)
+  // If proof of trust exists, return the verified result. The legacy
+  // top-level fields (`service`, `serviceProvider`, `outcome`,
+  // `verified`) are preserved unchanged so existing consumers continue
+  // to work; the new `validPresentations` / `invalidPresentations`
+  // arrays are exposed alongside.
   if (serviceProvider && service) {
     return {
       didDocument,
@@ -313,9 +571,235 @@ async function processDidDocument(
       verified: true,
       service,
       serviceProvider,
+      validPresentations,
+      invalidPresentations,
     }
   }
-  throw new TrustError(TrustErrorCode.NOT_FOUND, 'Valid serviceProvider and service were not found')
+  // No verified service/serviceProvider was assembled. Attach the
+  // partial-progress arrays to the thrown TrustError so that
+  // `handleTrustError` can forward them onto the final TrustResolution.
+  const err = new TrustError(TrustErrorCode.NOT_FOUND, 'Valid serviceProvider and service were not found')
+  err.validPresentations = validPresentations
+  err.invalidPresentations = invalidPresentations
+  throw err
+}
+
+/** Result of processing a single linked-vp service entry. */
+type LinkedVpResult =
+  | {
+      kind: 'vp-failed'
+      vpUrl?: string
+      errorCode: TrustErrorCode
+      errorMessage: string
+    }
+  | {
+      kind: 'vp-processed'
+      vpUrl: string
+      validCredentials: { credentialId: string; credential: ICredential; outcome: TrustResolutionOutcome }[]
+      invalidCredentials: { credentialId: string; errorCode: TrustErrorCode; errorMessage: string }[]
+    }
+
+/** Aggregated context for processing a single linked-vp entry. */
+type LinkedVpContext = {
+  did: string
+  serviceId: string
+  presentationType: PresentationType
+  verifiablePublicRegistries: VerifiablePublicRegistry[]
+  didResolver: Resolver
+  skipDigestSRICheck?: boolean
+  logger: IVerreLogger
+  cache?: InternalResolverConfig['cache']
+}
+
+/**
+ * Process a single `LinkedVerifiablePresentation` service entry end-to-end:
+ * dereference the VP, verify its signature, then validate every credential
+ * it contains against the appropriate flow (VTC or VTJSC).
+ *
+ * Returns a structured result so the caller can update the per-VP /
+ * per-credential outcome arrays without losing partial progress.
+ */
+async function processLinkedVp(didService: Service, ctx: LinkedVpContext): Promise<LinkedVpResult> {
+  const { logger, presentationType, verifiablePublicRegistries, didResolver, skipDigestSRICheck } = ctx
+
+  // 1) Dereference the VP.
+  let vp: W3cPresentation
+  let vpUrl: string
+  try {
+    vp = await resolveServiceVP(didService)
+    const endpoints = Array.isArray(didService.serviceEndpoint)
+      ? didService.serviceEndpoint
+      : [didService.serviceEndpoint]
+    vpUrl = (endpoints[0] as string) ?? ctx.serviceId
+  } catch (error) {
+    const code = error instanceof TrustError ? error.metadata.errorCode! : TrustErrorCode.INVALID_REQUEST
+    return {
+      kind: 'vp-failed',
+      errorCode: mapToFineGrainedCode(code, 'vp-fetch'),
+      errorMessage: error instanceof Error ? error.message : String(error),
+    }
+  }
+
+  // 2) Verify VP signature (this also recursively verifies each embedded
+  // credential's own signature; one bad signature poisons the whole VP).
+  const sig = await verifySignature(vp as W3cJsonLdVerifiablePresentation, didResolver, logger)
+  if (!sig.result) {
+    return {
+      kind: 'vp-failed',
+      vpUrl,
+      errorCode: TrustErrorCode.VP_SIGNATURE_INVALID,
+      errorMessage: `Verifiable presentation signature invalid: ${sig.error ?? 'unknown'}`,
+    }
+  }
+
+  // 3) Extract all credentials from the VP.
+  let vcs: W3cVerifiableCredential[]
+  try {
+    vcs = getCredentials(vp)
+  } catch (error) {
+    const code = error instanceof TrustError ? error.metadata.errorCode! : TrustErrorCode.INVALID
+    return {
+      kind: 'vp-failed',
+      vpUrl,
+      errorCode: mapToFineGrainedCode(code, 'vp-format'),
+      errorMessage: error instanceof Error ? error.message : String(error),
+    }
+  }
+
+  // 4) Validate each credential independently.
+  const validCredentials: {
+    credentialId: string
+    credential: ICredential
+    outcome: TrustResolutionOutcome
+  }[] = []
+  const invalidCredentials: { credentialId: string; errorCode: TrustErrorCode; errorMessage: string }[] = []
+
+  for (const vc of vcs) {
+    const credentialId = (vc.id as string) ?? '<no-id>'
+    try {
+      const { credential, outcome } =
+        presentationType === PresentationType.VTJSC
+          ? await processVtjscCredential(vc, verifiablePublicRegistries, skipDigestSRICheck, logger)
+          : await processCredential(vc, verifiablePublicRegistries, skipDigestSRICheck, logger)
+      validCredentials.push({ credentialId, credential, outcome })
+    } catch (error) {
+      const innerMessage = error instanceof Error ? error.message : String(error)
+      let coarse = error instanceof TrustError ? error.metadata.errorCode! : TrustErrorCode.INVALID
+      // Refine INVALID_PERMISSIONS into MISSING vs NOT_EFFECTIVE based on
+      // the message. This is the only legacy code with an internal split.
+      if (coarse === TrustErrorCode.INVALID_PERMISSIONS) {
+        coarse = refinePermissionCode(innerMessage)
+      }
+      const fineGrained = mapToFineGrainedCode(coarse, 'cred-other')
+      invalidCredentials.push({
+        credentialId,
+        errorCode: fineGrained,
+        errorMessage: innerMessage,
+      })
+      logger.debug('Credential validation failed', {
+        credentialId,
+        coarse,
+        fineGrained,
+        message: innerMessage,
+      })
+    }
+  }
+
+  return { kind: 'vp-processed', vpUrl, validCredentials, invalidCredentials }
+}
+
+/**
+ * Validate a Verifiable Trust JSON Schema Credential (VTJSC) presented
+ * directly via a `-jsc-vp` / `-vtjsc-vp` linked-vp service.
+ *
+ * VTJSCs differ from VTCs in two ways:
+ *
+ * 1. They are themselves credentials of type `JsonSchemaCredential` whose
+ *    inner `credentialSchema.type` is `JsonSchema`. There is no outer
+ *    "user-data" credential.
+ * 2. The relevant trust assertion is **not** an ISSUER permission for a
+ *    schema, but rather "the Ecosystem DID controls this schema". The
+ *    cryptographic proof comes from the credential signature; the
+ *    Ecosystem-vs-registry binding is enforced via the optional
+ *    `allowedEcsEcosystems` whitelist on the matched registry.
+ *
+ * The returned `ICredential` has `id` and `issuer` (the Ecosystem DID)
+ * populated and `schemaType` set to the identified ECS variant when
+ * applicable, or `'unknown'` for non-ECS schemas.
+ */
+async function processVtjscCredential(
+  w3cCredential: W3cVerifiableCredential,
+  verifiablePublicRegistries: VerifiablePublicRegistry[],
+  skipDigestSRICheck: boolean = false,
+  logger: IVerreLogger,
+): Promise<{ credential: ICredential; outcome: TrustResolutionOutcome }> {
+  logger.debug('Processing VTJSC credential', { id: w3cCredential.id })
+
+  const { schema, subject } = resolveSchemaAndSubject(w3cCredential, logger)
+
+  // A VTJSC's own schema MUST be `JsonSchema` (i.e. the credential IS the
+  // JSC). VTC-like indirection (`JsonSchemaCredential`) is rejected here.
+  if (schema.type !== 'JsonSchema') {
+    throw new TrustError(
+      TrustErrorCode.CREDENTIAL_INVALID_FORMAT,
+      `VTJSC must declare credentialSchema.type === 'JsonSchema'; got '${schema.type}'`,
+    )
+  }
+
+  const refUrl = getRefUrl(subject)
+  const { schemaUrl, outcome, adapter, registry } = resolveTrustRegistry(refUrl, verifiablePublicRegistries)
+
+  const { digestSRI: schemaDigestSRI } = schema as Record<string, any>
+  const { digestSRI: subjectDigestSRI } = subject as Record<string, any>
+
+  const [schemaRawText, subjectSchemaRawText] = await Promise.all([
+    fetchText(schema.id),
+    adapter ? adapter.fetchSchema(schemaUrl) : fetchText(schemaUrl),
+  ])
+
+  if (!skipDigestSRICheck) {
+    verifyDigestSRI(schemaRawText, schemaDigestSRI, logger)
+    verifyDigestSRI(subjectSchemaRawText, subjectDigestSRI, logger)
+  }
+
+  const schemaData = JSON.parse(schemaRawText)
+  const subjectSchema = JSON.parse(subjectSchemaRawText)
+
+  // The VTJSC must validate against its own meta-schema (typically the
+  // W3C JsonSchemaCredential schema). No `attrs` validation step here:
+  // there is no outer credential carrying user data.
+  validateSchemaContent(schemaData, w3cCredential)
+
+  const ecsType = identifySchema(subjectSchema)
+
+  // ECS whitelist enforcement: identical to the VTC path, except that
+  // for VTJSCs the JSC issuer is simply `w3cCredential.issuer` (no
+  // recursion).
+  if (ecsType !== null && registry?.allowedEcsEcosystems && registry.allowedEcsEcosystems.length > 0) {
+    const jscIssuer =
+      typeof w3cCredential.issuer === 'string'
+        ? w3cCredential.issuer
+        : (w3cCredential.issuer as { id?: string } | undefined)?.id
+    if (!jscIssuer || !registry.allowedEcsEcosystems.includes(jscIssuer)) {
+      throw new TrustError(
+        TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED,
+        `Ecosystem DID ${jscIssuer ?? '<unknown>'} is not whitelisted to issue ${ecsType} schemas in registry ${registry.id}`,
+      )
+    }
+    logger.debug('VTJSC ecosystem whitelist passed', { jscIssuer, ecsType, registryId: registry.id })
+  }
+
+  const issuer =
+    typeof w3cCredential.issuer === 'string'
+      ? w3cCredential.issuer
+      : ((w3cCredential.issuer as { id?: string } | undefined)?.id ?? '')
+
+  const credential: ICredential = {
+    schemaType: ecsType ?? 'unknown',
+    id: (w3cCredential.id as string) ?? '',
+    issuer,
+  } as ICredential
+  return { credential, outcome }
 }
 
 /**
@@ -358,41 +842,21 @@ async function resolveServiceVP(service: Service): Promise<W3cPresentation> {
 }
 
 /**
- * Extracts a valid verifiable credential from a Verifiable Presentation.
- * @param vp - The Verifiable Presentation to parse.
- * @param verifiablePublicRegistries - The registry public registries URLs used for validation and lookup.
- * @returns A valid Verifiable Credential.
- * @throws Error if no valid credential is found.
+ * Returns all Verifiable Credentials inside a Verifiable Presentation.
+ *
+ * Unlike the original `getCredential` (single-result, fail-fast), this
+ * iterator returns *every* credential whose `type` array includes
+ * `VerifiableCredential`. This enables per-credential validation downstream
+ * so a multi-credential VP that is partially valid can be reported
+ * accurately (some credentials in `validPresentations`, others in
+ * `invalidPresentations`).
+ *
+ * @param vp - The Verifiable Presentation to inspect.
+ * @returns Non-empty array of credentials. Throws if the VP holds none.
+ * @throws {TrustError} `NOT_FOUND` when the VP has no credentials at all,
+ *                     `INVALID` when none are typed as `VerifiableCredential`.
  */
-async function getVerifiedCredential(
-  vp: W3cPresentation,
-  verifiablePublicRegistries: VerifiablePublicRegistry[],
-  logger: IVerreLogger,
-  didResolver: Resolver,
-  skipDigestSRICheck?: boolean,
-): Promise<{ credential: ICredential; outcome: TrustResolutionOutcome }> {
-  logger.debug('Verifying credential', { vp })
-
-  const w3cCredential = getCredential(vp)
-  const isVerified = await verifySignature(vp as W3cJsonLdVerifiablePresentation, didResolver, logger)
-  if (!isVerified.result) {
-    throw new TrustError(
-      TrustErrorCode.INVALID,
-      'The verifiable credential proof is not valid with: ' + isVerified.error,
-    )
-  }
-
-  logger.debug('Credential verified successfully')
-  return await processCredential(w3cCredential, verifiablePublicRegistries, skipDigestSRICheck, logger)
-}
-
-/**
- * Finds a valid Verifiable Credential inside a Verifiable Presentation.
- * @param vp - The Verifiable Presentation to search.
- * @returns The first valid Verifiable Credential.
- * @throws Error if no valid credential is found.
- */
-function getCredential(vp: W3cPresentation): W3cVerifiableCredential {
+function getCredentials(vp: W3cPresentation): W3cVerifiableCredential[] {
   if (
     !vp.verifiableCredential ||
     !Array.isArray(vp.verifiableCredential) ||
@@ -401,15 +865,15 @@ function getCredential(vp: W3cPresentation): W3cVerifiableCredential {
     throw new TrustError(TrustErrorCode.NOT_FOUND, 'No verifiable credential found in the response')
   }
 
-  const validCredential = vp.verifiableCredential.find(vc => vc.type.includes('VerifiableCredential')) as
-    | W3cVerifiableCredential
-    | undefined
+  const validCredentials = vp.verifiableCredential.filter(vc =>
+    vc.type.includes('VerifiableCredential'),
+  ) as W3cVerifiableCredential[]
 
-  if (!validCredential) {
+  if (validCredentials.length === 0) {
     throw new TrustError(TrustErrorCode.INVALID, 'No valid verifiable credential found in the response')
   }
 
-  return validCredential
+  return validCredentials
 }
 
 /**
@@ -468,7 +932,7 @@ async function processCredential(
     try {
       // Extract the reference URL from the subject if it contains a JSON Schema reference
       const refUrl = getRefUrl(subject)
-      const { trustRegistry, schemaId, outcome, schemaUrl, adapter } = resolveTrustRegistry(
+      const { trustRegistry, schemaId, outcome, schemaUrl, adapter, registry } = resolveTrustRegistry(
         refUrl,
         verifiablePublicRegistries,
       )
@@ -508,8 +972,36 @@ async function processCredential(
 
       // Validate the credential subject attributes against the JSON schema content
       validateSchemaContent(subjectSchema, attrs)
+
+      const ecsType = identifySchema(subjectSchema)
+
+      // ECS Trust Registry whitelist enforcement.
+      //
+      // When the credential's underlying JSON Schema is one of the four
+      // Essential Credential Schemas (Service / Organization / Persona /
+      // UserAgent) AND the matched registry declares a non-empty
+      // `allowedEcsEcosystems` whitelist, the JSC issuer (i.e. the
+      // Ecosystem DID that owns the schema; available as
+      // `w3cCredential.issuer` in this recursive call) MUST appear in
+      // the whitelist. When the registry declares no whitelist (or an
+      // empty one), any Ecosystem DID is accepted — preserving the
+      // pre-feature behaviour for backward compatibility.
+      if (ecsType !== null && registry?.allowedEcsEcosystems && registry.allowedEcsEcosystems.length > 0) {
+        const jscIssuer =
+          typeof w3cCredential.issuer === 'string'
+            ? w3cCredential.issuer
+            : (w3cCredential.issuer as { id?: string } | undefined)?.id
+        if (!jscIssuer || !registry.allowedEcsEcosystems.includes(jscIssuer)) {
+          throw new TrustError(
+            TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED,
+            `Ecosystem DID ${jscIssuer ?? '<unknown>'} is not whitelisted to issue ${ecsType} schemas in registry ${registry.id}`,
+          )
+        }
+        logger.debug('ECS ecosystem whitelist passed', { jscIssuer, ecsType, registryId: registry.id })
+      }
+
       const credential = {
-        schemaType: identifySchema(subjectSchema),
+        schemaType: ecsType,
         id,
         issuer,
         ...attrs,
@@ -517,6 +1009,10 @@ async function processCredential(
       return { credential, outcome }
     } catch (error) {
       logger.error('Failed to process credential', error)
+      // Preserve specific TrustError codes (e.g. ECS_TRUST_REGISTRY_NOT_WHITELISTED)
+      // raised explicitly above. Otherwise wrap with the legacy coarse code so
+      // existing consumers keep their behaviour.
+      if (error instanceof TrustError) throw error
       throw new TrustError(TrustErrorCode.INVALID, `Failed to validate credential: ${error.message}`)
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,34 @@ export type TrustResolution = {
   verified: boolean
   outcome: TrustResolutionOutcome
   metadata?: TrustResolutionMetadata
+  /**
+   * The Service credential extracted from a successfully resolved
+   * Verifiable Trust Credential (VTC). Preserved for backward
+   * compatibility; equivalent to the first ECS-SERVICE entry of
+   * `validPresentations`.
+   */
   service?: IService
+  /**
+   * The Service Provider credential (ECS-ORG or ECS-PERSONA) extracted
+   * from a successfully resolved VTC. Preserved for backward
+   * compatibility; equivalent to the first ECS-ORG/ECS-PERSONA entry
+   * of `validPresentations`.
+   */
   serviceProvider?: ICredential
+  /**
+   * All linked-vp service entries that were successfully dereferenced
+   * AND whose credentials passed verification. May overlap with
+   * `invalidPresentations` (same VP URL) when a multi-credential VP
+   * is partially valid: each credential is evaluated independently.
+   */
+  validPresentations?: VpOutcome[]
+  /**
+   * All linked-vp service entries that failed at least one validation
+   * step. Entries are grouped by error code per VP; a partially-valid
+   * VP appears here with the IDs of the failing credentials, while
+   * its passing credentials appear in `validPresentations`.
+   */
+  invalidPresentations?: VpOutcomeWithError[]
 }
 
 export type CredentialResolution = {
@@ -59,10 +85,94 @@ export interface IRegistryAdapter {
 }
 
 export type VerifiablePublicRegistry = {
+  /**
+   * Canonical identifier of the registry, used as a URL prefix to match
+   * `$ref` references in credential schemas (e.g. `vpr:verana:vna-testnet-1`).
+   */
   id: string
+  /**
+   * Alternative HTTP base URLs used to dereference schemas and permissions
+   * from the registry's indexer (e.g. `https://idx.testnet.verana.network/verana`).
+   */
   baseUrls: string[]
+  /**
+   * Marks whether this registry is considered production-grade. A non-production
+   * registry yields `TrustResolutionOutcome.VERIFIED_TEST` rather than `VERIFIED`
+   * even when validation succeeds.
+   */
   production: boolean
+  /**
+   * Optional in-process adapter for resolving registry operations without HTTP.
+   * Useful when verre runs inside the same node as the registry itself.
+   */
   adapter?: IRegistryAdapter
+  /**
+   * Optional whitelist of Ecosystem DIDs trusted to issue ECS-typed
+   * Verifiable Trust JSON Schema Credentials (VTJSCs) inside this registry.
+   *
+   * - When **omitted or empty**, any Ecosystem within this registry may issue
+   *   ECS schemas (current behaviour, fully backward compatible).
+   * - When **set**, an ECS-typed VTC whose underlying VTJSC is issued by an
+   *   Ecosystem DID NOT in this list is rejected with
+   *   `TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED`.
+   *
+   * Only applies to ECS-typed credentials; non-ECS credentials are unaffected.
+   */
+  allowedEcsEcosystems?: string[]
+}
+
+/**
+ * Classification of a Linked Verifiable Presentation (linked-vp) service entry
+ * in a DID Document, based on the fragment suffix of its service id.
+ *
+ * - `VTC`   — Verifiable Trust Credential presentation (`-c-vp` / `-vtc-vp`)
+ * - `VTJSC` — Verifiable Trust JSON Schema Credential presentation
+ *             (`-jsc-vp` / `-vtjsc-vp`)
+ */
+export enum PresentationType {
+  VTC = 'vtc',
+  VTJSC = 'vtjsc',
+}
+
+/**
+ * A linked-vp service entry that was successfully dereferenced and yielded
+ * at least one valid credential.
+ */
+export type VpOutcome = {
+  /** Service entry id from the DID Document (e.g. `did:web:foo#vpr-schemas-service-c-vp`). */
+  serviceId: string
+  /** Resolved VP URL (the dereferenced `serviceEndpoint`). */
+  vpUrl: string
+  /** Classification of the linked-vp fragment. */
+  presentationType: PresentationType
+  /** IDs of the credentials inside the VP that passed verification. */
+  credentialIds: string[]
+}
+
+/**
+ * A linked-vp service entry that failed at least one validation step.
+ *
+ * For VP-level failures (e.g. `DEREFERENCE_FAILED`, `VP_SIGNATURE_INVALID`)
+ * `credentialIds` is empty and `presentationType` may be `undefined` if the
+ * fragment itself was non-conformant.
+ *
+ * For per-credential failures inside an otherwise valid VP, `credentialIds`
+ * lists the IDs that failed with `errorCode`. The valid credentials of the
+ * same VP are reported separately under `validPresentations`.
+ */
+export type VpOutcomeWithError = {
+  /** Service entry id from the DID Document. */
+  serviceId: string
+  /** Resolved VP URL when known; may equal the service id for fragment errors. */
+  vpUrl: string
+  /** Classification of the linked-vp fragment, if it could be classified. */
+  presentationType?: PresentationType
+  /** IDs of credentials that failed with `errorCode`; empty for VP-level errors. */
+  credentialIds: string[]
+  /** Fine-grained error code; see `TrustErrorCode`. */
+  errorCode: TrustErrorCode
+  /** Human-readable diagnostic. */
+  errorMessage: string
 }
 
 export type DidDocumentResult = {
@@ -142,7 +252,22 @@ export enum VerifiablePresentationState {
   TERMINATED = 'TERMINATED',
 }
 
+/**
+ * Fine-grained error codes emitted by verre during trust resolution.
+ *
+ * The first set of values (lowercase, snake_case) are the historical
+ * coarse-grained codes preserved for backward compatibility with existing
+ * downstream consumers (e.g. the verana-resolver). The second set
+ * (UPPER_SNAKE_CASE) are the new per-VP / per-credential codes attached
+ * to entries of `TrustResolution.invalidPresentations` and to
+ * `TrustResolutionMetadata` when a more specific cause is known.
+ *
+ * New codes are emitted by the per-VP error path inside
+ * `processDidDocument`; the existing throw-sites in `didValidator` continue
+ * to raise the legacy coarse codes so external behaviour is unchanged.
+ */
 export enum TrustErrorCode {
+  // --- Legacy coarse codes (backward compatible) ---
   INVALID = 'invalid',
   NOT_FOUND = 'not_found',
   NOT_SUPPORTED = 'not_supported',
@@ -150,6 +275,45 @@ export enum TrustErrorCode {
   INVALID_REQUEST = 'invalid_request',
   SCHEMA_MISMATCH = 'schema_mismatch',
   VERIFICATION_FAILED = 'verification_failed',
+
+  // --- Fine-grained VP-level codes ---
+  /** The fragment portion of the linked-vp service id is not recognised. */
+  FRAGMENT_NOT_CONFORMANT = 'FRAGMENT_NOT_CONFORMANT',
+  /** The VP `serviceEndpoint` could not be dereferenced (HTTP/network error). */
+  DEREFERENCE_FAILED = 'DEREFERENCE_FAILED',
+  /** The dereferenced document is not a valid Verifiable Presentation. */
+  VP_INVALID_FORMAT = 'VP_INVALID_FORMAT',
+  /** The VP signature could not be verified. */
+  VP_SIGNATURE_INVALID = 'VP_SIGNATURE_INVALID',
+  /** The VP holder DID does not match the DID being resolved. */
+  VP_HOLDER_MISMATCH = 'VP_HOLDER_MISMATCH',
+  /** The VP contains zero credentials. */
+  VP_NO_CREDENTIALS = 'VP_NO_CREDENTIALS',
+
+  // --- Fine-grained credential-level codes ---
+  /** The credential signature could not be verified. */
+  CREDENTIAL_SIGNATURE_INVALID = 'CREDENTIAL_SIGNATURE_INVALID',
+  /** The credential is missing required fields (e.g. `credentialSchema`). */
+  CREDENTIAL_INVALID_FORMAT = 'CREDENTIAL_INVALID_FORMAT',
+  /** The credential's claimed schema could not be dereferenced. */
+  SCHEMA_NOT_FOUND = 'SCHEMA_NOT_FOUND',
+  /** The credential payload does not validate against its declared schema. */
+  CREDENTIAL_SCHEMA_MISMATCH = 'CREDENTIAL_SCHEMA_MISMATCH',
+  /** The schema digest stored in the credential does not match the fetched schema. */
+  SCHEMA_DIGEST_MISMATCH = 'SCHEMA_DIGEST_MISMATCH',
+  /** The issuer lacks an active ISSUER permission for the credential's schema. */
+  ISSUER_PERMISSION_MISSING = 'ISSUER_PERMISSION_MISSING',
+  /** The issuer's permission is not effective at the credential's issuance date. */
+  ISSUER_PERMISSION_NOT_EFFECTIVE = 'ISSUER_PERMISSION_NOT_EFFECTIVE',
+
+  // --- Fine-grained ECS / Trust Registry codes ---
+  /**
+   * The Ecosystem DID that issued an ECS VTJSC is not in the registry's
+   * `allowedEcsEcosystems` whitelist (see `VerifiablePublicRegistry`).
+   */
+  ECS_TRUST_REGISTRY_NOT_WHITELISTED = 'ECS_TRUST_REGISTRY_NOT_WHITELISTED',
+  /** The credential references a registry not configured in `verifiablePublicRegistries`. */
+  REGISTRY_NOT_CONFIGURED = 'REGISTRY_NOT_CONFIGURED',
 }
 
 /**

--- a/src/utils/trustError.ts
+++ b/src/utils/trustError.ts
@@ -1,15 +1,31 @@
 import { DIDDocument } from 'did-resolver'
 
-import { TrustResolutionMetadata, TrustErrorCode, TrustResolutionOutcome } from '../types.js'
+import {
+  TrustResolutionMetadata,
+  TrustErrorCode,
+  TrustResolutionOutcome,
+  VpOutcome,
+  VpOutcomeWithError,
+} from '../types.js'
 
 import { buildMetadata } from './helper.js'
 
 /**
  * Custom error class for handling trust-related errors.
- * Extends the standard `Error` class and includes metadata for detailed resolution information.
+ *
+ * Extends the standard `Error` class with `metadata` carrying the
+ * coarse-grained outcome of the failure. May optionally carry the
+ * per-VP / per-credential outcome arrays accumulated by
+ * `processDidDocument` so that they survive to `handleTrustError`
+ * (and thence to the final `TrustResolution` returned to callers
+ * even on the invalid path).
  */
 export class TrustError extends Error {
   metadata: TrustResolutionMetadata
+  /** Optional partial-progress accumulator surfaced on the error path. */
+  validPresentations?: VpOutcome[]
+  /** Optional partial-progress accumulator surfaced on the error path. */
+  invalidPresentations?: VpOutcomeWithError[]
 
   constructor(code: TrustErrorCode, message: string) {
     super(message)
@@ -19,6 +35,13 @@ export class TrustError extends Error {
 
 /**
  * Handles trust errors and ensures metadata is properly included in the response.
+ *
+ * When the thrown `TrustError` carries `validPresentations` /
+ * `invalidPresentations` arrays (attached by `processDidDocument` on the
+ * partial-failure path), they are forwarded onto the resulting
+ * `TrustResolution` so that consumers can still inspect which VPs
+ * succeeded and which failed even though the overall resolution did not
+ * yield a verified service + serviceProvider pair.
  *
  * @param {unknown} error - The error to be processed.
  * @param {DIDDocument} [didDocument] - An optional DID Document associated with the error.
@@ -31,6 +54,8 @@ export function handleTrustError(error: unknown, didDocument?: DIDDocument) {
       outcome: TrustResolutionOutcome.INVALID,
       verified: false,
       metadata: error.metadata,
+      validPresentations: error.validPresentations,
+      invalidPresentations: error.invalidPresentations,
     }
   }
   return {

--- a/tests/unit/perVpOutcomes.test.ts
+++ b/tests/unit/perVpOutcomes.test.ts
@@ -1,0 +1,638 @@
+/**
+ * Tests for the per-VP / per-credential outcome accumulator and the
+ * spec v4 fragment-suffix conformance work introduced in
+ * `feat/per-vp-outcomes`.
+ *
+ * NOTE: this file imports mocks **directly** from the sub-files instead
+ * of from `tests/__mocks__/index.ts` because the index re-exports
+ * `agent.ts`, which in turn loads `@openwallet-foundation/askar-nodejs`
+ * (a native module). The unit-test environment has no native bindings
+ * available, but none of the assertions below need an Askar agent —
+ * we mock `verifySignature` and `fetch` instead.
+ */
+import { Resolver } from 'did-resolver'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { ECS, resolveDID, TrustErrorCode, TrustResolutionOutcome, VerifiablePublicRegistry } from '../../src'
+import { resolverInstance } from '../../src/libraries'
+import * as signatureVerifier from '../../src/utils/verifier'
+import { fetchMocker } from '../__mocks__/fetch'
+import {
+  didExtIssuer,
+  didSelfIssued,
+  mockCredentialSchemaOrg,
+  mockCredentialSchemaSer,
+  mockDidDocumentSelfIssued,
+  mockOrgSchema,
+  mockOrgVc,
+  mockPermission,
+  mockResolverSelfIssued,
+  mockServiceSchemaSelfIssued,
+  mockServiceVcSelfIssued,
+  mockW3cJsonSchemaV2,
+  createVerifiableCredential,
+  createVerifiablePresentation,
+  verifiablePublicRegistries,
+} from '../__mocks__/object'
+
+const mockResolversByDid: Record<string, any> = {
+  [didSelfIssued]: { ...mockResolverSelfIssued },
+}
+
+/** Fetch responses needed for the canonical happy-path resolution of `didSelfIssued`. */
+const baselineFetchResponses = {
+  'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+  'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+  'https://ecs-trust-registry/service-credential-schema-credential.json': {
+    ok: true,
+    status: 200,
+    data: mockServiceSchemaSelfIssued,
+  },
+  'https://ecs-trust-registry/org-credential-schema-credential.json': {
+    ok: true,
+    status: 200,
+    data: mockOrgSchema,
+  },
+  'https://www.w3.org/ns/credentials/json-schema/v2.json': {
+    ok: true,
+    status: 200,
+    data: mockW3cJsonSchemaV2,
+  },
+  'https://testTrust.com/v1/cs/js/12345671': { ok: true, status: 200, data: mockCredentialSchemaOrg },
+  'https://testTrust.com/v1/cs/js/12345678': { ok: true, status: 200, data: mockCredentialSchemaSer },
+  'https://testtrust.com/v1/perm/v1/list?did=did%3Aweb%3Aservice.self-issued.example.com&type=ISSUER&response_max_size=1&schema_id=12345678':
+    { ok: true, status: 200, data: mockPermission },
+  'https://testtrust.com/v1/perm/v1/list?did=did%3Aweb%3Aservice.self-issued.example.com&type=ISSUER&response_max_size=1&schema_id=12345671':
+    { ok: true, status: 200, data: mockPermission },
+}
+
+describe('per-VP outcome accumulator', () => {
+  beforeEach(() => {
+    // Stub the JSON-LD signature check; signature semantics are tested separately.
+    vi.spyOn(signatureVerifier, 'verifySignature').mockResolvedValue({ result: true })
+    fetchMocker.enable()
+  })
+
+  afterEach(() => {
+    fetchMocker.reset()
+    fetchMocker.disable()
+    vi.clearAllMocks()
+    resolverInstance.clear()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Spec v4 fragment-suffix conformance
+  // ---------------------------------------------------------------------------
+
+  describe('linked-vp fragment classification', () => {
+    it('resolves DID Documents with v4 -vtc-vp suffixes', async () => {
+      const v4DidDoc = {
+        ...mockDidDocumentSelfIssued,
+        didDocument: {
+          ...mockDidDocumentSelfIssued.didDocument,
+          service: [
+            {
+              id: `${didSelfIssued}#vpr-schemas-service-vtc-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-ser-self-issued'],
+            },
+            {
+              id: `${didSelfIssued}#vpr-schemas-org-vtc-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-org'],
+            },
+          ],
+        },
+      }
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async () => v4DidDoc as any)
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+
+      expect(result.verified).toBe(true)
+      expect(result.outcome).toBe(TrustResolutionOutcome.VERIFIED)
+      expect(result.validPresentations).toHaveLength(2)
+      expect(result.validPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            serviceId: `${didSelfIssued}#vpr-schemas-service-vtc-vp`,
+            presentationType: 'vtc',
+          }),
+          expect.objectContaining({
+            serviceId: `${didSelfIssued}#vpr-schemas-org-vtc-vp`,
+            presentationType: 'vtc',
+          }),
+        ]),
+      )
+      expect(result.invalidPresentations).toEqual([])
+    })
+
+    it('preserves backward-compat with legacy v3 -c-vp suffixes', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+
+      expect(result.verified).toBe(true)
+      expect(result.validPresentations).toHaveLength(2)
+      // Existing legacy fields remain populated for backward compat.
+      expect(result.service).toBeDefined()
+      expect(result.serviceProvider).toBeDefined()
+    })
+
+    it('handles a DID Document that mixes v3 and v4 suffixes', async () => {
+      const mixedDidDoc = {
+        ...mockDidDocumentSelfIssued,
+        didDocument: {
+          ...mockDidDocumentSelfIssued.didDocument,
+          service: [
+            {
+              // v4
+              id: `${didSelfIssued}#vpr-schemas-service-vtc-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-ser-self-issued'],
+            },
+            {
+              // v3 (legacy)
+              id: `${didSelfIssued}#vpr-schemas-org-c-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-org'],
+            },
+          ],
+        },
+      }
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async () => mixedDidDoc as any)
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.verified).toBe(true)
+      expect(result.validPresentations).toHaveLength(2)
+    })
+
+    it('emits FRAGMENT_NOT_CONFORMANT for vpr-* fragments with an unknown suffix', async () => {
+      const badFragmentDoc = {
+        ...mockDidDocumentSelfIssued,
+        didDocument: {
+          ...mockDidDocumentSelfIssued.didDocument,
+          service: [
+            {
+              id: `${didSelfIssued}#vpr-schemas-service-c-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-ser-self-issued'],
+            },
+            {
+              id: `${didSelfIssued}#vpr-schemas-org-c-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-org'],
+            },
+            {
+              // bogus suffix
+              id: `${didSelfIssued}#vpr-schemas-bogus-suffix`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/vp-noop'],
+            },
+          ],
+        },
+      }
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async () => badFragmentDoc as any)
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.verified).toBe(true) // still resolves on the two valid VPs
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            serviceId: `${didSelfIssued}#vpr-schemas-bogus-suffix`,
+            errorCode: TrustErrorCode.FRAGMENT_NOT_CONFORMANT,
+          }),
+        ]),
+      )
+    })
+
+    it('silently skips non-vpr LinkedVerifiablePresentation services (no FRAGMENT_NOT_CONFORMANT)', async () => {
+      const docWithUnrelatedLvp = {
+        ...mockDidDocumentSelfIssued,
+        didDocument: {
+          ...mockDidDocumentSelfIssued.didDocument,
+          service: [
+            ...mockDidDocumentSelfIssued.didDocument.service,
+            {
+              // Not a vpr fragment at all — must be silently ignored.
+              id: `${didSelfIssued}#linked-domains-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/some-other-vp'],
+            },
+          ],
+        },
+      }
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async () => docWithUnrelatedLvp as any)
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.invalidPresentations).toEqual([])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Per-VP failure isolation (Promise.allSettled behaviour)
+  // ---------------------------------------------------------------------------
+
+  describe('per-VP error reporting', () => {
+    it('reports DEREFERENCE_FAILED when the VP endpoint returns 404', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses({
+        ...baselineFetchResponses,
+        // org VP: simulate 404
+        'https://example.com/vp-org': { ok: false, status: 404, data: { error: 'not found' } },
+      })
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      // service VP is still valid → service exists; but no org → not verified
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            serviceId: `${didSelfIssued}#vpr-schemas-org-c-vp`,
+            errorCode: TrustErrorCode.DEREFERENCE_FAILED,
+          }),
+        ]),
+      )
+    })
+
+    it('reports VP_SIGNATURE_INVALID when verifySignature returns result=false', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      // Restore real verifySignature to fake a single-VP failure
+      vi.spyOn(signatureVerifier, 'verifySignature').mockImplementation(async (doc: any) => {
+        if (doc.id?.includes('verifiable-presentation')) {
+          // Fail signature for the OrgVP, succeed for ServiceVP
+          if (
+            doc.holder === didSelfIssued &&
+            doc.verifiableCredential[0]?.credentialSubject?.name === 'Example Corp'
+          ) {
+            return { result: false, error: 'fake signature failure' }
+          }
+        }
+        return { result: true }
+      })
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            errorCode: TrustErrorCode.VP_SIGNATURE_INVALID,
+          }),
+        ]),
+      )
+    })
+
+    it('reports ISSUER_PERMISSION_MISSING when the perm endpoint returns no permissions', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses({
+        ...baselineFetchResponses,
+        // Org credential's permission lookup: empty list → no ISSUER permission
+        'https://testtrust.com/v1/perm/v1/list?did=did%3Aweb%3Aservice.self-issued.example.com&type=ISSUER&response_max_size=1&schema_id=12345671':
+          { ok: true, status: 200, data: { permissions: [] } },
+      })
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            errorCode: TrustErrorCode.ISSUER_PERMISSION_MISSING,
+          }),
+        ]),
+      )
+    })
+
+    it('reports ISSUER_PERMISSION_NOT_EFFECTIVE when issuanceDate is outside the permission window', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses({
+        ...baselineFetchResponses,
+        // Org perm: effective range strictly AFTER the credential issuance date
+        'https://testtrust.com/v1/perm/v1/list?did=did%3Aweb%3Aservice.self-issued.example.com&type=ISSUER&response_max_size=1&schema_id=12345671':
+          {
+            ok: true,
+            status: 200,
+            data: {
+              permissions: [
+                {
+                  type: 'ISSUER',
+                  created: '2099-01-01T00:00:00.000Z',
+                  effective_from: '2099-01-01T00:00:00.000Z',
+                  effective_until: '2099-12-31T23:59:59.000Z',
+                },
+              ],
+            },
+          },
+      })
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            errorCode: TrustErrorCode.ISSUER_PERMISSION_NOT_EFFECTIVE,
+          }),
+        ]),
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Multi-credential VP handling
+  // ---------------------------------------------------------------------------
+
+  describe('multi-credential VPs', () => {
+    it('processes all credentials in a multi-credential VP', async () => {
+      // Build a VP that holds TWO credentials: a service VC and an org VC.
+      const multiVp = {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        holder: didSelfIssued,
+        type: ['VerifiablePresentation'],
+        verifiableCredential: [
+          createVerifiableCredential(
+            didSelfIssued,
+            {
+              id: 'https://ecs-trust-registry/service-credential-schema-credential.json',
+              type: 'JsonSchemaCredential',
+            },
+            mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
+          ),
+          createVerifiableCredential(
+            didSelfIssued,
+            {
+              id: 'https://ecs-trust-registry/org-credential-schema-credential.json',
+              type: 'JsonSchemaCredential',
+            },
+            mockOrgVc.verifiableCredential[0].credentialSubject,
+          ),
+        ],
+        id: `https://example.com/multi-cred-vp-${didSelfIssued}.jsonld`,
+        proof: {
+          type: 'Ed25519Signature2018',
+          created: '2024-02-08T17:38:46Z',
+          verificationMethod: `${didSelfIssued}#key-1`,
+          proofPurpose: 'assertionMethod',
+          jws: 'eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..signature',
+        },
+      }
+
+      const singleSvcDidDoc = {
+        ...mockDidDocumentSelfIssued,
+        didDocument: {
+          ...mockDidDocumentSelfIssued.didDocument,
+          service: [
+            {
+              id: `${didSelfIssued}#vpr-schemas-multi-c-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/multi-cred-vp'],
+            },
+          ],
+        },
+      }
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async () => singleSvcDidDoc as any)
+      fetchMocker.setMockResponses({
+        ...baselineFetchResponses,
+        'https://example.com/multi-cred-vp': { ok: true, status: 200, data: multiVp },
+      })
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+
+      // The single VP yielded TWO valid credentials, both reported under the
+      // same `validPresentations` entry (one entry per VP).
+      expect(result.verified).toBe(true)
+      expect(result.validPresentations).toHaveLength(1)
+      expect(result.validPresentations?.[0].credentialIds).toHaveLength(2)
+      // Legacy fields still populated.
+      expect(result.service).toBeDefined()
+      expect(result.serviceProvider).toBeDefined()
+    })
+
+    it('splits a partially-valid multi-credential VP across both arrays', async () => {
+      // 1 valid (service) + 1 invalid (org with no ISSUER permission)
+      const partialVp = {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        holder: didSelfIssued,
+        type: ['VerifiablePresentation'],
+        verifiableCredential: [
+          createVerifiableCredential(
+            didSelfIssued,
+            {
+              id: 'https://ecs-trust-registry/service-credential-schema-credential.json',
+              type: 'JsonSchemaCredential',
+            },
+            mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
+          ),
+          createVerifiableCredential(
+            didSelfIssued,
+            {
+              id: 'https://ecs-trust-registry/org-credential-schema-credential.json',
+              type: 'JsonSchemaCredential',
+            },
+            mockOrgVc.verifiableCredential[0].credentialSubject,
+          ),
+        ],
+        id: `https://example.com/partial-vp-${didSelfIssued}.jsonld`,
+        proof: {
+          type: 'Ed25519Signature2018',
+          created: '2024-02-08T17:38:46Z',
+          verificationMethod: `${didSelfIssued}#key-1`,
+          proofPurpose: 'assertionMethod',
+          jws: 'eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..signature',
+        },
+      }
+      // Give each credential a distinct, deterministic id so we can assert membership.
+      partialVp.verifiableCredential[0].id = 'urn:uuid:cred-service-OK'
+      partialVp.verifiableCredential[1].id = 'urn:uuid:cred-org-FAIL'
+
+      const singleSvcDidDoc = {
+        ...mockDidDocumentSelfIssued,
+        didDocument: {
+          ...mockDidDocumentSelfIssued.didDocument,
+          service: [
+            {
+              id: `${didSelfIssued}#vpr-schemas-mixed-c-vp`,
+              type: 'LinkedVerifiablePresentation',
+              serviceEndpoint: ['https://example.com/partial-vp'],
+            },
+          ],
+        },
+      }
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async () => singleSvcDidDoc as any)
+      fetchMocker.setMockResponses({
+        ...baselineFetchResponses,
+        'https://example.com/partial-vp': { ok: true, status: 200, data: partialVp },
+        // Org credential's permission lookup: empty → ISSUER_PERMISSION_MISSING
+        'https://testtrust.com/v1/perm/v1/list?did=did%3Aweb%3Aservice.self-issued.example.com&type=ISSUER&response_max_size=1&schema_id=12345671':
+          { ok: true, status: 200, data: { permissions: [] } },
+      })
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+
+      // Service credential succeeded.
+      expect(result.validPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            serviceId: `${didSelfIssued}#vpr-schemas-mixed-c-vp`,
+            credentialIds: expect.arrayContaining(['urn:uuid:cred-service-OK']),
+          }),
+        ]),
+      )
+      // Org credential failed, in the SAME serviceId.
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            serviceId: `${didSelfIssued}#vpr-schemas-mixed-c-vp`,
+            errorCode: TrustErrorCode.ISSUER_PERMISSION_MISSING,
+            credentialIds: expect.arrayContaining(['urn:uuid:cred-org-FAIL']),
+          }),
+        ]),
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // ECS Trust Registry whitelist (allowedEcsEcosystems)
+  // ---------------------------------------------------------------------------
+
+  describe('ECS ecosystem whitelist', () => {
+    /** Build a registry list scoped to the test schemas, with an optional whitelist. */
+    function registriesWithWhitelist(allowedEcsEcosystems?: string[]): VerifiablePublicRegistry[] {
+      return [
+        {
+          id: 'https://vpr-hostname/vpr',
+          baseUrls: ['https://testTrust.com'],
+          production: true,
+          allowedEcsEcosystems,
+        },
+        ...verifiablePublicRegistries.filter(r => r.id !== 'https://vpr-hostname/vpr'),
+      ]
+    }
+
+    it('rejects credentials whose JSC issuer is not in allowedEcsEcosystems', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithWhitelist(['did:web:some-other-ecosystem.example.com']),
+      })
+
+      expect(result.invalidPresentations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            errorCode: TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED,
+          }),
+        ]),
+      )
+    })
+
+    it('accepts credentials whose JSC issuer is in allowedEcsEcosystems', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      // The mock JSCs (mockServiceSchemaSelfIssued, mockOrgSchema) are issued
+      // by `didSelfIssued`. Whitelist that DID and resolution should pass.
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithWhitelist([didSelfIssued]),
+      })
+      expect(result.verified).toBe(true)
+      expect(
+        result.invalidPresentations?.some(
+          v => v.errorCode === TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED,
+        ),
+      ).toBeFalsy()
+    })
+
+    it('does not enforce the whitelist when allowedEcsEcosystems is empty/undefined', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithWhitelist(undefined),
+      })
+
+      expect(result.verified).toBe(true)
+      expect(
+        result.invalidPresentations?.some(
+          v => v.errorCode === TrustErrorCode.ECS_TRUST_REGISTRY_NOT_WHITELISTED,
+        ),
+      ).toBeFalsy()
+    })
+
+    it('does not enforce the whitelist when allowedEcsEcosystems is an empty array', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithWhitelist([]),
+      })
+
+      expect(result.verified).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Backward-compat assertions
+  // ---------------------------------------------------------------------------
+
+  describe('backward compatibility', () => {
+    it('preserves the legacy top-level fields (service, serviceProvider, outcome, verified)', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+
+      expect(result.verified).toBe(true)
+      expect(result.outcome).toBe(TrustResolutionOutcome.VERIFIED)
+      // `id` on the credential reflects the `credentialSubject.id` of the
+      // underlying VC (which is independent of the DID being resolved), so
+      // we only assert the discriminating `schemaType` and `issuer` here.
+      expect(result.service).toEqual(
+        expect.objectContaining({
+          schemaType: ECS.SERVICE,
+          issuer: didSelfIssued,
+        }),
+      )
+      expect(result.serviceProvider).toEqual(
+        expect.objectContaining({
+          schemaType: ECS.ORG,
+          issuer: didSelfIssued,
+        }),
+      )
+      // didDocument round-trip
+      expect(result.didDocument).toEqual(mockDidDocumentSelfIssued.didDocument)
+    })
+
+    it('returns empty arrays for valid/invalid presentations on full success when no failures occur', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.setMockResponses(baselineFetchResponses)
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+      expect(result.invalidPresentations).toEqual([])
+      // unused variable ensures linter does not complain on no-eslint-disable runs
+      void didExtIssuer
+      void createVerifiablePresentation
+    })
+  })
+})


### PR DESCRIPTION
Refactors `processDidDocument` to use Promise.allSettled for per-VP isolation and a new `processLinkedVp` helper that returns a structured result with valid/invalid credentials. The TrustResolution now carries optional `validPresentations` / `invalidPresentations` arrays alongside the legacy top-level fields, surfacing partial progress on both the success and error paths.

Spec v4 changes:
  - Recognise both `vpr-schemas-*` and `vpr-ecs-*` namespaces
  - Recognise both VTC suffixes (`-vtc-vp` v4 / `-c-vp` v3 legacy)
  - Recognise both VTJSC suffixes (`-vtjsc-vp` v4 long / `-jsc-vp` short)
  - Emit FRAGMENT_NOT_CONFORMANT for vpr-* fragments with unknown suffix
  - Add `processVtjscCredential` for VTJSC-direct presentations (no ISSUER permission required; credential is the JSC itself)

Multi-credential VPs are now processed credential-by-credential so a partial success is reported accurately. Failing credentials are grouped by erroby erroby erroby erroby erroby erroby erroby erroby erroby erroby erroby whiby erroby erroby erroby erroby erroby erroby erroby erroby eystem DIby erroby erroby erroby erroby erroby erroby erroby errobyt tests covering: v4/v3/mixed fragments, FRAGMENT_NOT_CONFORMANT, silent-skip for nosilent-skip for nosilent-skip for nosilent-skip for nosilent-sERMISSION_silent-skip for nosilent-skip for nosilent-skip for nosilent-skip llsiles + partial pass), allowedEcsEcosystems (allowed / rejected / empty / undefined), and backward-compat assertions.

The deprecated `getCredential` and `getVerifiedCredential` helpers are removed; `processLinkedVp` and `getCredentials` cover their use cases.