### PR TITLE
fix: reject revoked permissions during trust resolution

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -602,7 +602,13 @@ async function verifyPermission(
   logger.debug('Verifying permission', { schemaId, did, hasAdapter: !!adapter })
 
   let perm:
-    | { type: string; created: string; effective_from?: string | null; effective_until?: string | null }
+    | {
+        type: string
+        created: string
+        effective_from?: string | null
+        effective_until?: string | null
+        revoked?: number | string | null
+      }
     | undefined
 
   if (adapter) {
@@ -621,6 +627,12 @@ async function verifyPermission(
     throw new TrustError(
       TrustErrorCode.INVALID_PERMISSIONS,
       `No valid ${permissionType} permissions were found for the specified DID: ${did} for schema ${schemaId}`,
+    )
+
+  if (perm.revoked != null)
+    throw new TrustError(
+      TrustErrorCode.INVALID_PERMISSIONS,
+      `Permission for the specified DID: ${did} for schema ${schemaId} was revoked at ${perm.revoked}`,
     )
 
   const effectiveFrom = perm.effective_from ?? perm.created

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,9 @@ export interface IRegistryAdapter {
     schemaId: string,
     did: string,
     permissionType: PermissionType,
-  ): Promise<Pick<Permission, 'type' | 'created' | 'effective_from' | 'effective_until'> | undefined>
+  ): Promise<
+    Pick<Permission, 'type' | 'created' | 'effective_from' | 'effective_until' | 'revoked'> | undefined
+  >
 }
 
 export type VerifiablePublicRegistry = {


### PR DESCRIPTION
Closes #107

`verifyPermission` checks a perm's `type` and effective window but never `revoked`, so a perm revoked on-chain keeps resolving `authorized: true` until `effective_until`. Same function backs both issuer and verifier, so both stay trusted after revocation.

Found it on the MOSIP integration. Wired 0.3.0 directly to rule out the resolver cache and it still passed, so it's in verre, not the cache. Fix is a single guard when `perm.revoked != null`.
