### PR TITLE
fix: mark cjs build as commonjs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   resolve-version:
-    uses: 2060-io/organization/.github/workflows/resolve-version-call.yml@main
+    uses: 2060-io/organization/.github/workflows/resolve-version-call.yml@5f813454d8962db006c4e4466f3af1cf4af8dfa4 # main
     with:
       bump-minor-pre-major: false
 
@@ -24,9 +24,9 @@ jobs:
       RELEASE_TYPE: ${{ needs.resolve-version.outputs.release-type }}
     steps:
 
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.14.0'
           cache: pnpm

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,16 @@
   "main": "./build/cjs/index.js",
   "module": "./build/index.js",
   "exports": {
-    "require": "./build/cjs/index.js",
-    "import": "./build/index.js"
+    ".": {
+      "import": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "require": {
+        "types": "./build/cjs/index.d.ts",
+        "default": "./build/cjs/index.js"
+      }
+    }
   },
   "types": "./build/index.d.ts",
   "files": [
@@ -25,7 +33,7 @@
     "clean": "rimraf -rf ./build",
     "compile": "pnpm run compile:esm && pnpm run compile:cjs",
     "compile:esm": "tsc -p tsconfig.json",
-    "compile:cjs": "tsc -p tsconfig.cjs.json",
+    "compile:cjs": "tsc -p tsconfig.cjs.json && node scripts/fixup-cjs.mjs",
     "prepublishOnly": "pnpm run build",
     "check-types": "eslint \"{src,tests}/**/*.ts\"",
     "format": "prettier \"src/**/*.ts\" --write",

--- a/scripts/fixup-cjs.mjs
+++ b/scripts/fixup-cjs.mjs
@@ -1,8 +1,6 @@
 import { writeFileSync } from 'node:fs'
 
-// The package root declares "type": "module", which applies to every .js file
-// in the package. The CommonJS build under build/cjs/ must override that so Node
-// interprets those files as CommonJS instead of ESM.
+// The package root declares "type": "module", which applies to every .js file in the package.
 writeFileSync(
   new URL('../build/cjs/package.json', import.meta.url),
   JSON.stringify({ type: 'commonjs' }) + '\n',

--- a/scripts/fixup-cjs.mjs
+++ b/scripts/fixup-cjs.mjs
@@ -1,0 +1,9 @@
+import { writeFileSync } from 'node:fs'
+
+// The package root declares "type": "module", which applies to every .js file
+// in the package. The CommonJS build under build/cjs/ must override that so Node
+// interprets those files as CommonJS instead of ESM.
+writeFileSync(
+  new URL('../build/cjs/package.json', import.meta.url),
+  JSON.stringify({ type: 'commonjs' }) + '\n',
+)


### PR DESCRIPTION
**Changes**
- Create a script to generate the package.json file to support CommonJS (CJS) deployment for the library.