### PR TITLE
fix: guard async cache miss in DID trust resolution

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -184,7 +184,8 @@ function resolveTrustRegistry(
  */
 async function _resolve(did: string, options: InternalResolverConfig): Promise<TrustResolution> {
   const cached = options.cache?.get(did)
-  if (cached && (await cached).verified === true) return cached as Promise<TrustResolution>
+  const cachedValue = cached ? await cached : undefined
+  if (cachedValue?.verified === true) return cached as Promise<TrustResolution>
 
   try {
     const didDocument = await retrieveDidDocument(did, options.didResolver)


### PR DESCRIPTION
`_resolve` read `.verified` off the awaited cache value without checking it exists: `if (cached && (await cached).verified === true)`. When a caller passes an async cache whose `get()` resolves to `undefined` on a miss (e.g. the indexer's `DbDerefCache`), `cached` is a truthy promise, so the guard passes and `(await cached).verified` throws "Cannot read properties of undefined (reading 'verified')". This fires on the first (uncached) resolution of every DID, so all trust resolutions crash and every service shows UNTRUSTED.

Fix: await the cached value once into a local, then check it with optional chaining. On a miss it falls through to normal resolution. No change for real cache hits or the no-cache path.