### PR TITLE
feat: expose validity window, raw credential and per-credential failures in TrustResolution

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -27,6 +27,8 @@ import {
   PermissionType,
   LogLevel,
   IVerreLogger,
+  FailedCredential,
+  CREDENTIAL_FORMAT_LDP_VC,
 } from '../types.js'
 import {
   fetchJson,
@@ -258,7 +260,7 @@ async function processDidDocument(
   const patterns = [/^vpr-schemas.*-c-vp$/, /^vpr-ecs.*-c-vp$/]
 
   logger.debug('Processing DID services', { serviceCount: didDocument.service.length })
-  await Promise.all(
+  const serviceResults = await Promise.allSettled(
     didDocument.service.map(async didService => {
       const { type, id } = didService
       const matchesPattern = patterns.some(pattern => pattern.test(id.split('#')[1]))
@@ -301,6 +303,10 @@ async function processDidDocument(
       }
     }),
   )
+
+  const reasons = serviceResults.flatMap(result => (result.status === 'rejected' ? [result.reason] : []))
+  if (reasons.length > 0) throw aggregateCredentialFailures(reasons)
+
   service ??= credentials.find((cred): cred is IService => cred.schemaType === ECS.SERVICE)
   serviceProvider ??= credentials.find(
     (cred): cred is IOrg | IPersona => cred.schemaType === ECS.ORG || cred.schemaType === ECS.PERSONA,
@@ -377,14 +383,27 @@ async function getVerifiedCredential(
   const w3cCredential = getCredential(vp)
   const isVerified = await verifySignature(vp as W3cJsonLdVerifiablePresentation, didResolver, logger)
   if (!isVerified.result) {
+    const message = 'The verifiable credential proof is not valid with: ' + isVerified.error
     throw new TrustError(
       TrustErrorCode.INVALID,
-      'The verifiable credential proof is not valid with: ' + isVerified.error,
+      message,
+      isVerified.failedCredentials ?? [
+        {
+          id: typeof w3cCredential?.id === 'string' ? w3cCredential.id : undefined,
+          format: CREDENTIAL_FORMAT_LDP_VC,
+          error: isVerified.error ?? message,
+          errorCode: TrustErrorCode.INVALID,
+        },
+      ],
     )
   }
 
   logger.debug('Credential verified successfully')
-  return await processCredential(w3cCredential, verifiablePublicRegistries, skipDigestSRICheck, logger)
+  try {
+    return await processCredential(w3cCredential, verifiablePublicRegistries, skipDigestSRICheck, logger)
+  } catch (error) {
+    throw toCredentialFailure(error, w3cCredential)
+  }
 }
 
 /**
@@ -431,6 +450,10 @@ function getCredential(vp: W3cPresentation): W3cVerifiableCredential {
  * @param verifiablePublicRegistries - The registry public registries URLs used for validation and lookup.
  * @param issuer - Optional issuer DID to validate permissions against the trust registry.
  * @param attrs - Optional attributes to validate against the credential subject schema.
+ * @param sourceCredential - Optional credential the validation started from. When a credential
+ * declares a `JsonSchemaCredential`, this function recurses on the *schema* credential, so the
+ * credential originally presented has to be carried down to source the validity window and the
+ * raw credential exposed to consumers.
  * @returns A Promise resolving to the processed and validated credential.
  * @throws {TrustError} If validation fails due to missing fields, unsupported types, schema mismatch, or integrity check failure.
  */
@@ -442,6 +465,7 @@ async function processCredential(
   issuer?: string,
   issuanceDate?: string,
   attrs?: Record<string, string>,
+  sourceCredential?: W3cVerifiableCredential,
 ): Promise<{ credential: ICredential; outcome: TrustResolutionOutcome }> {
   logger.debug('Processing credential', { id: w3cCredential.id })
 
@@ -459,6 +483,7 @@ async function processCredential(
       w3cCredential.issuer as string,
       w3cCredential.issuanceDate as string,
       subject as Record<string, string>,
+      sourceCredential ?? w3cCredential,
     )
   }
 
@@ -509,11 +534,14 @@ async function processCredential(
 
       // Validate the credential subject attributes against the JSON schema content
       validateSchemaContent(subjectSchema, attrs)
+      const source = sourceCredential ?? w3cCredential
       const credential = {
         schemaType: identifySchema(subjectSchema),
         id,
         issuer,
         ...attrs,
+        ...normalizeValidityWindow(source),
+        raw: source,
       } as ICredential
       return { credential, outcome }
     } catch (error) {
@@ -585,6 +613,90 @@ function getRefUrl(subject: W3cCredentialSubject): string {
 
 function extractSchema<T>(value?: T | T[]): T | undefined {
   return Array.isArray(value) ? value[0] : value
+}
+
+/**
+ * Normalises a credential's validity window across credential data model versions.
+ *
+ * VCDM 2.0 uses `validFrom` / `validUntil`; VCDM 1.1 uses `issuanceDate` / `expirationDate`.
+ * Normalising here means consumers never have to branch on the credential version.
+ *
+ * Absent bounds are omitted rather than set to `undefined`, so a credential without an
+ * expiry simply has no `validUntil`.
+ *
+ * @param credential - The credential to read the window from.
+ * @returns The normalised `validFrom` / `validUntil` pair.
+ */
+function normalizeValidityWindow(credential: W3cVerifiableCredential): {
+  validFrom?: string
+  validUntil?: string
+} {
+  const vc = credential as unknown as Record<string, unknown>
+  const validFrom = (vc.validFrom ?? vc.issuanceDate) as string | undefined
+  const validUntil = (vc.validUntil ?? vc.expirationDate) as string | undefined
+
+  return {
+    ...(validFrom ? { validFrom } : {}),
+    ...(validUntil ? { validUntil } : {}),
+  }
+}
+
+/**
+ * Attaches per-credential failure detail to an error raised while validating a specific credential.
+ *
+ * Errors that already carry `failedCredentials` (e.g. signature failures identified per
+ * embedded VC) are passed through untouched, so the more precise attribution wins.
+ *
+ * @param error - The error raised while validating the credential.
+ * @param credential - The credential being validated when the error was raised.
+ * @returns A `TrustError` carrying the failure detail for this credential.
+ */
+function toCredentialFailure(error: unknown, credential: W3cVerifiableCredential): TrustError {
+  if (error instanceof TrustError && error.failedCredentials) return error
+
+  const message = error instanceof Error ? error.message : String(error)
+  const errorCode =
+    error instanceof TrustError
+      ? (error.metadata.errorCode ?? TrustErrorCode.INVALID)
+      : TrustErrorCode.INVALID
+
+  return new TrustError(errorCode, message, [
+    {
+      id: typeof credential?.id === 'string' ? credential.id : undefined,
+      format: CREDENTIAL_FORMAT_LDP_VC,
+      error: message,
+      errorCode,
+    },
+  ])
+}
+
+/**
+ * Combines failures raised across the DID document's services into a single error.
+ *
+ * The first failure supplies the top-level message and code (preserving the message a
+ * caller would previously have seen), while every failure contributes its per-credential
+ * detail so none is lost.
+ *
+ * @param reasons - The rejection reasons collected from the service resolutions.
+ * @returns A `TrustError` carrying the combined per-credential detail.
+ */
+function aggregateCredentialFailures(reasons: unknown[]): TrustError {
+  const failedCredentials = reasons.flatMap<FailedCredential>(reason =>
+    reason instanceof TrustError ? (reason.failedCredentials ?? []) : [],
+  )
+  const [first] = reasons
+  if (first instanceof TrustError) {
+    return new TrustError(
+      first.metadata.errorCode ?? TrustErrorCode.INVALID,
+      first.message,
+      failedCredentials,
+    )
+  }
+  return new TrustError(
+    TrustErrorCode.INVALID,
+    first instanceof Error ? first.message : String(first),
+    failedCredentials,
+  )
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { W3cVerifiableCredential } from '@credo-ts/core'
+
 import { DIDDocument, Resolver } from 'did-resolver'
 
 // types
@@ -8,6 +10,16 @@ export type TrustResolution = {
   metadata?: TrustResolutionMetadata
   service?: IService
   serviceProvider?: ICredential
+  failedCredentials?: FailedCredential[]
+}
+
+export const CREDENTIAL_FORMAT_LDP_VC = 'ldp_vc'
+
+export type FailedCredential = {
+  id?: string
+  format: string
+  error: string
+  errorCode: TrustErrorCode
 }
 
 export type CredentialResolution = {
@@ -182,6 +194,9 @@ export interface BaseCredential {
   schemaType: ECS | 'unknown'
   id: string
   issuer: string
+  validFrom?: string
+  validUntil?: string
+  raw?: W3cVerifiableCredential
 }
 
 export interface IOrg extends BaseCredential {

--- a/src/utils/trustError.ts
+++ b/src/utils/trustError.ts
@@ -1,6 +1,11 @@
 import { DIDDocument } from 'did-resolver'
 
-import { TrustResolutionMetadata, TrustErrorCode, TrustResolutionOutcome } from '../types.js'
+import {
+  TrustResolutionMetadata,
+  TrustErrorCode,
+  TrustResolutionOutcome,
+  FailedCredential,
+} from '../types.js'
 
 import { buildMetadata } from './helper.js'
 
@@ -10,10 +15,12 @@ import { buildMetadata } from './helper.js'
  */
 export class TrustError extends Error {
   metadata: TrustResolutionMetadata
+  failedCredentials?: FailedCredential[]
 
-  constructor(code: TrustErrorCode, message: string) {
+  constructor(code: TrustErrorCode, message: string, failedCredentials?: FailedCredential[]) {
     super(message)
     this.metadata = buildMetadata(code, message)
+    if (failedCredentials?.length) this.failedCredentials = failedCredentials
   }
 }
 
@@ -31,6 +38,7 @@ export function handleTrustError(error: unknown, didDocument?: DIDDocument) {
       outcome: TrustResolutionOutcome.INVALID,
       verified: false,
       metadata: error.metadata,
+      ...(error.failedCredentials ? { failedCredentials: error.failedCredentials } : {}),
     }
   }
   return {

--- a/src/utils/verifier.ts
+++ b/src/utils/verifier.ts
@@ -7,7 +7,7 @@ import { base58, base64, base64url } from '@scure/base'
 import { Resolver, VerificationMethod } from 'did-resolver'
 
 import { createDocumentLoader } from '../libraries/index.js'
-import { TrustErrorCode, IVerreLogger } from '../types.js'
+import { TrustErrorCode, IVerreLogger, FailedCredential, CREDENTIAL_FORMAT_LDP_VC } from '../types.js'
 
 import { hash } from './crypto.js'
 import { TrustError } from './trustError.js'
@@ -33,15 +33,16 @@ const createMessageDigest = () => ({
  * recursively verifies the embedded credentials.
  *
  * @param document - A W3C Verifiable Presentation or Verifiable Credential in JSON-LD format.
- * @returns A promise that resolves to `true` if the proof is valid (including all nested VCs), or `false` otherwise.
- *
- * @throws Error if the document is not a valid VP or VC, or if any embedded credential fails validation.
+ * @returns A promise resolving to `{ result: true }` if the proof is valid (including all nested VCs).
+ * On failure, `result` is `false` and — when specific embedded credentials were at fault —
+ * `failedCredentials` identifies which ones and why.
  */
 export async function verifySignature(
   document: W3cJsonLdVerifiablePresentation | W3cJsonLdVerifiableCredential,
   didResolver: Resolver,
   logger: IVerreLogger,
-): Promise<{ result: boolean; error?: string }> {
+): Promise<{ result: boolean; error?: string; failedCredentials?: FailedCredential[] }> {
+  let jsonLdCredentials: W3cJsonLdVerifiableCredential[] = []
   try {
     if (
       !document.proof ||
@@ -53,13 +54,17 @@ export async function verifySignature(
     }
     const isPresentation = document.type.includes('VerifiablePresentation')
 
-    let vcPromises: Promise<{ result: boolean; error?: string }>[] = []
+    let vcPromises: Promise<{
+      result: boolean
+      error?: string
+      failedCredentials?: FailedCredential[]
+    }>[] = []
     if (isPresentation && isVerifiablePresentation(document)) {
       logger.debug('Verifying embedded credentials in presentation')
       const credentials = Array.isArray(document.verifiableCredential)
         ? document.verifiableCredential
         : [document.verifiableCredential]
-      const jsonLdCredentials = credentials.filter((vc): vc is W3cJsonLdVerifiableCredential => 'proof' in vc)
+      jsonLdCredentials = credentials.filter((vc): vc is W3cJsonLdVerifiableCredential => 'proof' in vc)
       logger.debug('Processing embedded credentials', { count: jsonLdCredentials.length })
       vcPromises = jsonLdCredentials.map(vc => verifySignature(vc, didResolver, logger))
     }
@@ -70,7 +75,7 @@ export async function verifySignature(
       logger,
     )
     if (!result.isValid) {
-      const error = JSON.stringify(result?.error)
+      const error = typeof result.error === 'string' ? result.error : JSON.stringify(result?.error)
       logger.error('Signature verification failed', { error })
       return { result: result.isValid, error }
     }
@@ -79,11 +84,24 @@ export async function verifySignature(
 
     if (vcPromises.length > 0) {
       const vcResults = await Promise.all(vcPromises)
-      const allCredentialsVerified = vcResults.every(r => r.result === true)
-      if (!allCredentialsVerified) {
+      const failedCredentials = vcResults.flatMap<FailedCredential>((r, index) => {
+        if (r.result) return []
+        const vc = jsonLdCredentials[index]
+        return [
+          {
+            id: typeof vc?.id === 'string' ? vc.id : undefined,
+            format: CREDENTIAL_FORMAT_LDP_VC,
+            error: r.error ?? 'Signature verification failed',
+            errorCode: TrustErrorCode.VERIFICATION_FAILED,
+          },
+          ...(r.failedCredentials ?? []),
+        ]
+      })
+      if (failedCredentials.length > 0) {
         throw new TrustError(
           TrustErrorCode.VERIFICATION_FAILED,
           'One or more verifiable credentials failed signature verification.',
+          failedCredentials,
         )
       }
       logger.debug('All embedded credentials verified successfully')
@@ -91,7 +109,11 @@ export async function verifySignature(
     return { result: result.isValid }
   } catch (error) {
     logger.error('Signature verification exception', error)
-    return { result: false, error: error.message }
+    return {
+      result: false,
+      error: error.message,
+      failedCredentials: error instanceof TrustError ? error.failedCredentials : undefined,
+    }
   }
 }
 

--- a/tests/integration/network.test.ts
+++ b/tests/integration/network.test.ts
@@ -3,6 +3,7 @@ import { Resolver } from 'did-resolver'
 import { describe, it, beforeAll, afterAll, vi, expect } from 'vitest'
 
 import {
+  CREDENTIAL_FORMAT_LDP_VC,
   fetchJson,
   InMemoryCache,
   PermissionType,
@@ -125,11 +126,17 @@ describe('Integration with Verana Blockchain', () => {
           ...linkedVpService?.verifiableCredential?.[0]?.credentialSubject,
           issuer: did,
           schemaType: 'ecs-service',
+          validFrom: linkedVpService?.verifiableCredential?.[0]?.issuanceDate,
+          validUntil: linkedVpService?.verifiableCredential?.[0]?.expirationDate,
+          raw: linkedVpService?.verifiableCredential?.[0],
         },
         serviceProvider: {
           ...linkedVpOrg?.verifiableCredential?.[0]?.credentialSubject,
           issuer: did,
           schemaType: 'ecs-org',
+          validFrom: linkedVpOrg?.verifiableCredential?.[0]?.issuanceDate,
+          validUntil: linkedVpOrg?.verifiableCredential?.[0]?.expirationDate,
+          raw: linkedVpOrg?.verifiableCredential?.[0],
         },
       }),
     )
@@ -186,6 +193,17 @@ describe('Integration with Verana Blockchain', () => {
     expect(result.metadata).toMatchObject({
       errorCode: TrustErrorCode.INVALID,
     })
+
+    expect(result.failedCredentials).toHaveLength(2)
+    expect(result.failedCredentials).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          format: CREDENTIAL_FORMAT_LDP_VC,
+          error: 'Invalid or missing JWS detached signature',
+          errorCode: TrustErrorCode.VERIFICATION_FAILED,
+        }),
+      ]),
+    )
   })
 
   it('should resolve and validate a real self-signed credential end-to-end', async () => {

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -1,7 +1,15 @@
 import { Resolver } from 'did-resolver'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-import { ECS, IVerreLogger, PermissionType, resolveDID, TrustResolutionOutcome } from '../../src'
+import {
+  CREDENTIAL_FORMAT_LDP_VC,
+  ECS,
+  IVerreLogger,
+  PermissionType,
+  resolveDID,
+  TrustErrorCode,
+  TrustResolutionOutcome,
+} from '../../src'
 import { resolverInstance } from '../../src/libraries'
 import * as signatureVerifier from '../../src/utils/verifier'
 import {
@@ -109,15 +117,57 @@ describe('DidValidator', () => {
             id: didSelfIssued,
             issuer: didSelfIssued,
             ...mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
+            validFrom: mockServiceVcSelfIssued.verifiableCredential[0].issuanceDate,
+            validUntil: mockServiceVcSelfIssued.verifiableCredential[0].expirationDate,
+            raw: mockServiceVcSelfIssued.verifiableCredential[0],
           },
           serviceProvider: {
             schemaType: ECS.ORG,
             id: didSelfIssued,
             issuer: didSelfIssued,
             ...mockOrgVc.verifiableCredential[0].credentialSubject,
+            validFrom: mockOrgVc.verifiableCredential[0].issuanceDate,
+            validUntil: mockOrgVc.verifiableCredential[0].expirationDate,
+            raw: mockOrgVc.verifiableCredential[0],
           },
         }),
       )
+    })
+
+    it('should report which credentials failed validation, not just an overall outcome.', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+      vi.spyOn(signatureVerifier, 'verifySignature').mockResolvedValue({
+        result: false,
+        error: 'Ed25519 signature verification failed',
+        failedCredentials: [
+          {
+            id: 'https://example.tr/credentials/OrganizationJsonSchemaCredential',
+            format: CREDENTIAL_FORMAT_LDP_VC,
+            error: 'Ed25519 signature verification failed',
+            errorCode: TrustErrorCode.VERIFICATION_FAILED,
+          },
+        ],
+      })
+      fetchMocker.setMockResponses({
+        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+        'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+      })
+
+      const result = await resolveDID(didSelfIssued, { verifiablePublicRegistries })
+
+      expect(result.verified).toBe(false)
+      expect(result.outcome).toBe(TrustResolutionOutcome.INVALID)
+      expect(result.metadata?.errorMessage).toBeDefined()
+
+      expect(result.failedCredentials).toHaveLength(2)
+      expect(result.failedCredentials?.[0]).toEqual({
+        id: 'https://example.tr/credentials/OrganizationJsonSchemaCredential',
+        format: CREDENTIAL_FORMAT_LDP_VC,
+        error: 'Ed25519 signature verification failed',
+        errorCode: TrustErrorCode.VERIFICATION_FAILED,
+      })
     })
 
     it('should work correctly when the issuer is not "did" without params.', async () => {
@@ -190,12 +240,18 @@ describe('DidValidator', () => {
             id: didSelfIssued,
             issuer: didSelfIssued,
             ...mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            validFrom: mockServiceExtIssuerVc.verifiableCredential[0].issuanceDate,
+            validUntil: mockServiceExtIssuerVc.verifiableCredential[0].expirationDate,
+            raw: mockServiceExtIssuerVc.verifiableCredential[0],
           },
           serviceProvider: {
             schemaType: ECS.ORG,
             id: didSelfIssued,
             issuer: didSelfIssued,
             ...mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            validFrom: mockOrgVcWithoutIssuer.verifiableCredential[0].issuanceDate,
+            validUntil: mockOrgVcWithoutIssuer.verifiableCredential[0].expirationDate,
+            raw: mockOrgVcWithoutIssuer.verifiableCredential[0],
           },
         }),
       )
@@ -281,12 +337,18 @@ describe('DidValidator', () => {
             id: didSelfIssued,
             issuer: didSelfIssued,
             ...mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            validFrom: mockServiceExtIssuerVc.verifiableCredential[0].issuanceDate,
+            validUntil: mockServiceExtIssuerVc.verifiableCredential[0].expirationDate,
+            raw: mockServiceExtIssuerVc.verifiableCredential[0],
           },
           serviceProvider: {
             schemaType: ECS.ORG,
             id: didSelfIssued,
             issuer: didSelfIssued,
             ...mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            validFrom: mockOrgVcWithoutIssuer.verifiableCredential[0].issuanceDate,
+            validUntil: mockOrgVcWithoutIssuer.verifiableCredential[0].expirationDate,
+            raw: mockOrgVcWithoutIssuer.verifiableCredential[0],
           },
         }),
       )


### PR DESCRIPTION
## Changes

To complete https://github.com/verana-labs/verana-indexer/issues/365, the indexer now exposes additional credential fields according to the specification.

- Include `failedCredentials` in the outcome.
- Include `validFrom`, `validUntil`, and `raw` in the `CredentialResolution` response.

Example response:

```json
{
  "outcome": "verified",
  "verified": true,
  "didDocument": {
    "id": "did:webvh:...:dm.gov-id-verifier.demos.dev.2060.io"
  },
  "service": {
    "schemaType": "ecs-service",
    "id": "did:webvh:...:dm.gov-id-verifier.demos.dev.2060.io",
    "issuer": "did:webvh:...:dm.gov-id-org.demos.dev.2060.io",
    "name": "Gov ID verifier",
    "type": "VerifiableService",
    "description": "A demo service to verify Gov ID credentials",
    "validFrom": "2026-05-12T17:54:27.522Z",
    "validUntil": "2036-05-09T17:54:27.522Z",
    "raw": {
      "id": "did:webvh:...#6377f02f-1b09-485b-b0cc-2f6fd5f67a68",
      "type": [
        "VerifiableCredential",
        "VerifiableTrustCredential"
      ],
      "issuer": "did:webvh:...:dm.gov-id-org.demos.dev.2060.io",
      "credentialSubject": {
        "id": "did:webvh:...:dm.gov-id-verifier.demos.dev.2060.io",
        "name": "Gov ID verifier",
        "type": "VerifiableService"
      },
      "proof": {
        "type": "Ed25519Signature2020",
        "verificationMethod": "did:webvh:...#key-1"
      }
    }
  }
}
```

> **Note:** The newly exposed fields are **`validFrom`**, **`validUntil`**, and **`raw`**. The `raw` field contains the original credential as returned by the resolver.