### PR TITLE
fix: accept spec vpr-schemas-*-vtc-vp linked-VP fragments

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -60,6 +60,14 @@ import {
  * @returns A promise that resolves to a `TrustResolution` object containing the resolution result,
  * DID document metadata, and trust validation outcome.
  */
+// Linked-VP service fragments a trust resolver considers. [VT-CRED-W3C-LINKED-VP] mandates
+// #vpr-schemas-*-vtc-vp; the -c-vp forms are kept for backward compatibility with older agents.
+export const LINKED_VP_FRAGMENT_PATTERNS = [
+  /^vpr-schemas-.*-vtc-vp$/,
+  /^vpr-schemas.*-c-vp$/,
+  /^vpr-ecs.*-c-vp$/,
+]
+
 export async function resolveDID(did: string, options: ResolverConfig): Promise<TrustResolution> {
   const internalOptions: InternalResolverConfig = {
     ...options,
@@ -255,13 +263,12 @@ async function processDidDocument(
   let serviceProvider: ICredential | undefined
   let service: IService | undefined = attrs
   let outcome: TrustResolutionOutcome = TrustResolutionOutcome.NOT_TRUSTED
-  const patterns = [/^vpr-schemas.*-c-vp$/, /^vpr-ecs.*-c-vp$/]
 
   logger.debug('Processing DID services', { serviceCount: didDocument.service.length })
   await Promise.all(
     didDocument.service.map(async didService => {
       const { type, id } = didService
-      const matchesPattern = patterns.some(pattern => pattern.test(id.split('#')[1]))
+      const matchesPattern = LINKED_VP_FRAGMENT_PATTERNS.some(pattern => pattern.test(id.split('#')[1]))
       logger.debug('Evaluating DID service', { id, type, matchesPattern })
       if (type === 'LinkedVerifiablePresentation' && matchesPattern) {
         logger.debug('Resolving linked VP service', { id })

--- a/tests/unit/linkedVpFragments.test.ts
+++ b/tests/unit/linkedVpFragments.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { LINKED_VP_FRAGMENT_PATTERNS } from '../../src/resolver/didValidator'
+
+const matches = (fragment: string): boolean => LINKED_VP_FRAGMENT_PATTERNS.some(p => p.test(fragment))
+
+describe('linked-VP fragment patterns', () => {
+  it('matches the spec fragments ([VT-CRED-W3C-LINKED-VP], #vpr-schemas-*-vtc-vp)', () => {
+    expect(matches('vpr-schemas-service-vtc-vp')).toBe(true)
+    expect(matches('vpr-schemas-org-vtc-vp')).toBe(true)
+    expect(matches('vpr-schemas-persona-vtc-vp')).toBe(true)
+  })
+
+  it('still matches the legacy -c-vp fragments', () => {
+    expect(matches('vpr-schemas-service-c-vp')).toBe(true)
+    expect(matches('vpr-ecs-service-c-vp')).toBe(true)
+  })
+
+  it('does not match unrelated fragments', () => {
+    expect(matches('whois')).toBe(false)
+    expect(matches('vpr-schemas-service-vtjsc-vp')).toBe(false)
+    expect(matches('didcomm')).toBe(false)
+  })
+})


### PR DESCRIPTION
The trust resolver only matched linked-VP service fragments ending in `-c-vp`, but [VT-CRED-W3C-LINKED-VP] mandates `#vpr-schemas-*-vtc-vp` (e.g. `#vpr-schemas-service-vtc-vp`). So a spec-conformant DID Document is silently skipped and the DID never resolves as trusted.

Adds the spec `vpr-schemas-*-vtc-vp` pattern alongside the existing `-c-vp` ones (backward-compatible), lifts the patterns to an exported const.