### PR TITLE
fix: accept unpadded base64url JWS signatures

### DIFF
--- a/src/utils/verifier.ts
+++ b/src/utils/verifier.ts
@@ -3,7 +3,7 @@ import type { W3cJsonLdVerifiableCredential, W3cJsonLdVerifiablePresentation } f
 import jsonld from '@digitalcredentials/jsonld'
 import { ed25519 } from '@noble/curves/ed25519.js'
 import { bytesToHex, concatBytes } from '@noble/hashes/utils'
-import { base58, base64, base64url } from '@scure/base'
+import { base58, base64, base64urlnopad } from '@scure/base'
 import { Resolver, VerificationMethod } from 'did-resolver'
 
 import { createDocumentLoader } from '../libraries/index.js'
@@ -11,6 +11,9 @@ import { TrustErrorCode, IVerreLogger, FailedCredential, CREDENTIAL_FORMAT_LDP_V
 
 import { hash } from './crypto.js'
 import { TrustError } from './trustError.js'
+
+// RFC 7515 base64url is unpadded, but legacy signers emit padded values; accept both
+const decodeBase64url = (value: string): Uint8Array => base64urlnopad.decode(value.replace(/=+$/u, ''))
 
 // Ed25519 multicodec prefix: 0xed01
 const ED25519_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01])
@@ -205,7 +208,7 @@ async function verifyJsonLdCredential(
     }
 
     const [header, , signaturePart] = jws.split('.')
-    signatureBytes = base64url.decode(signaturePart)
+    signatureBytes = decodeBase64url(signaturePart)
     verifyData = concatBytes(
       new TextEncoder().encode(`${header}.`),
       proofHash as Uint8Array,
@@ -291,7 +294,7 @@ async function resolvePublicKey(
   if (vm.publicKeyJwk && typeof vm.publicKeyJwk === 'object') {
     const jwk = vm.publicKeyJwk as Record<string, unknown>
     if (jwk.x && typeof jwk.x === 'string') {
-      return base64url.decode(jwk.x as string)
+      return decodeBase64url(jwk.x as string)
     }
   }
 

--- a/tests/unit/jwsPadding.test.ts
+++ b/tests/unit/jwsPadding.test.ts
@@ -1,0 +1,40 @@
+import { Resolver } from 'did-resolver'
+import { describe, expect, it } from 'vitest'
+
+import { IVerreLogger } from '../../src/types'
+import { verifySignature } from '../../src/utils/verifier'
+import { integrationDidDoc, linkedVpService } from '../__mocks__'
+
+const resolver = {
+  resolve: async () => ({
+    didResolutionMetadata: {},
+    didDocumentMetadata: {},
+    didDocument: integrationDidDoc,
+  }),
+} as unknown as Resolver
+
+const silentLogger: IVerreLogger = { debug() {}, info() {}, warn() {}, error() {} }
+
+const stripJwsPadding = (value: unknown): unknown =>
+  JSON.parse(JSON.stringify(value), (key, v) =>
+    key === 'jws' && typeof v === 'string' ? v.replace(/=+$/u, '') : v,
+  )
+
+describe('JWS base64url padding tolerance', () => {
+  it('verifies unpadded JWS signatures (RFC 7515)', async () => {
+    const vp = stripJwsPadding(linkedVpService) as Parameters<typeof verifySignature>[0]
+    const { result, error } = await verifySignature(vp, resolver, silentLogger)
+    expect(error).toBeUndefined()
+    expect(result).toBe(true)
+  })
+
+  it('still verifies legacy padded JWS signatures', async () => {
+    const { result, error } = await verifySignature(
+      linkedVpService as Parameters<typeof verifySignature>[0],
+      resolver,
+      silentLogger,
+    )
+    expect(error).toBeUndefined()
+    expect(result).toBe(true)
+  })
+})


### PR DESCRIPTION
RFC 7515 base64url is unpadded, but the verifier decodes JWS signatures (and JWK x values) with @scure/base base64url, which requires padding. Any spec-compliant Ed25519Signature2018 signer, including current credo, fails verification with "padding: invalid, string should have whole number of bytes". The existing fixtures pass only because their JWS carry non-standard padding.

Decodes through a padding-tolerant helper (strip trailing = then base64urlnopad), accepting both compliant and legacy signatures. Regression test covers both, the unpadded case fails on main.