### PR TITLE
feat: gate ECS classification on an ecosystem allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ async function verifyPermissions(options: VerifyPermissionsOptions): Promise<{ v
 * **didResolver** (*Resolver*, optional): Custom universal resolver instance.
 * **cache** (*TrustResolutionCache<string, Promise<TrustResolution>*, optional): Cache store for trust resolution results. When provided, a successful resolution is stored keyed by DID and returned directly on subsequent calls. Any object implementing the `TrustResolutionCache` interface is accepted, the library provides `InMemoryCache` as a built-in implementation.
 * **skipDigestSRICheck** (*boolean*, optional): When true, skips verification of the credential integrity (digestSRI). Defaults to false.
-* **ecsEcosystems** (*EcsEcosystem[]*, optional): Ecosystems whitelisted to create Essential Credential Schemas per [WL-ECS] (`{ did, vpr }` pairs, where `vpr` matches a `verifiablePublicRegistries[].id`). When set, a schema whose Ecosystem is not whitelisted degrades to a regular VTC. When undefined, any Ecosystem is accepted. Requires a registry adapter implementing `fetchSchemaEcosystemDid`.
+* **ecsEcosystems** (*EcsEcosystem[]*, optional): Ecosystems whitelisted to create Essential Credential Schemas per [WL-ECS] (`{ did, vpr }` pairs, where `vpr` matches a `verifiablePublicRegistries[].id`). When set, a schema whose Ecosystem is not whitelisted degrades to a regular VTC. When undefined, any Ecosystem is accepted. Requires a registry adapter; verre throws if one is not configured. Resolutions are cached per whitelist.
 * **logger** (*IVerreLogger*, optional): Logger instance for the resolution process. Accepts any object that implements the `IVerreLogger` interface.
 
 ---

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ async function verifyPermissions(options: VerifyPermissionsOptions): Promise<{ v
 * **didResolver** (*Resolver*, optional): Custom universal resolver instance.
 * **cache** (*TrustResolutionCache<string, Promise<TrustResolution>*, optional): Cache store for trust resolution results. When provided, a successful resolution is stored keyed by DID and returned directly on subsequent calls. Any object implementing the `TrustResolutionCache` interface is accepted, the library provides `InMemoryCache` as a built-in implementation.
 * **skipDigestSRICheck** (*boolean*, optional): When true, skips verification of the credential integrity (digestSRI). Defaults to false.
+* **ecsEcosystems** (*EcsEcosystem[]*, optional): Ecosystems allowed to produce ECS credentials (`{ did, vpr }` pairs, where `vpr` is the registry id). When set, credentials whose schema belongs to any other ecosystem are treated as ordinary VTCs. When undefined, any ecosystem is accepted.
 * **logger** (*IVerreLogger*, optional): Logger instance for the resolution process. Accepts any object that implements the `IVerreLogger` interface.
 
 ---

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ async function verifyPermissions(options: VerifyPermissionsOptions): Promise<{ v
 * **didResolver** (*Resolver*, optional): Custom universal resolver instance.
 * **cache** (*TrustResolutionCache<string, Promise<TrustResolution>*, optional): Cache store for trust resolution results. When provided, a successful resolution is stored keyed by DID and returned directly on subsequent calls. Any object implementing the `TrustResolutionCache` interface is accepted, the library provides `InMemoryCache` as a built-in implementation.
 * **skipDigestSRICheck** (*boolean*, optional): When true, skips verification of the credential integrity (digestSRI). Defaults to false.
-* **ecsEcosystems** (*EcsEcosystem[]*, optional): Ecosystems allowed to produce ECS credentials (`{ did, vpr }` pairs, where `vpr` is the registry id). When set, credentials whose schema belongs to any other ecosystem are treated as ordinary VTCs. When undefined, any ecosystem is accepted.
+* **ecsEcosystems** (*EcsEcosystem[]*, optional): Ecosystems whitelisted to create Essential Credential Schemas per [WL-ECS] (`{ did, vpr }` pairs, where `vpr` matches a `verifiablePublicRegistries[].id`). When set, a schema whose Ecosystem is not whitelisted degrades to a regular VTC. When undefined, any Ecosystem is accepted. Requires a registry adapter implementing `fetchSchemaEcosystemDid`.
 * **logger** (*IVerreLogger*, optional): Logger instance for the resolution process. Accepts any object that implements the `IVerreLogger` interface.
 
 ---

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -196,8 +196,19 @@ function resolveTrustRegistry(
  *
  * @internal
  */
+// a resolution made under a whitelist must not be served to a caller using a different one
+function cacheKeyFor(did: string, ecsEcosystems?: EcsEcosystem[]): string {
+  if (!ecsEcosystems) return did
+  const whitelist = ecsEcosystems
+    .map(e => `${e.vpr}|${e.did}`)
+    .sort()
+    .join(',')
+  return `${did}#ecs:${whitelist}`
+}
+
 async function _resolve(did: string, options: InternalResolverConfig): Promise<TrustResolution> {
-  const cached = options.cache?.get(did)
+  const cacheKey = cacheKeyFor(did, options.ecsEcosystems)
+  const cached = options.cache?.get(cacheKey)
   const cachedValue = cached ? await cached : undefined
   if (cachedValue?.verified === true) return cached as Promise<TrustResolution>
 
@@ -206,7 +217,7 @@ async function _resolve(did: string, options: InternalResolverConfig): Promise<T
 
     try {
       const result = await processDidDocument(did, didDocument, options)
-      options.cache?.set(did, Promise.resolve(result))
+      options.cache?.set(cacheKey, Promise.resolve(result))
       return result
     } catch (error) {
       return handleTrustError(error, didDocument)

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -162,8 +162,7 @@ function resolveTrustRegistry(
   outcome: TrustResolutionOutcome
   schemaUrl: string
   adapter?: IRegistryAdapter
-  registryId?: string
-  registryBaseUrl?: string
+  vprId?: string
 } {
   const registry = verifiablePublicRegistries?.find(registry => refUrl.startsWith(registry.id))
   const schemaUrl =
@@ -182,8 +181,7 @@ function resolveTrustRegistry(
     outcome,
     schemaUrl,
     adapter: registry?.adapter,
-    registryId: registry?.id,
-    registryBaseUrl: registry?.baseUrls[0],
+    vprId: registry?.id,
   }
 }
 
@@ -511,8 +509,10 @@ async function processCredential(
     try {
       // Extract the reference URL from the subject if it contains a JSON Schema reference
       const refUrl = getRefUrl(subject)
-      const { trustRegistry, schemaId, outcome, schemaUrl, adapter, registryId, registryBaseUrl } =
-        resolveTrustRegistry(refUrl, verifiablePublicRegistries)
+      const { trustRegistry, schemaId, outcome, schemaUrl, adapter, vprId } = resolveTrustRegistry(
+        refUrl,
+        verifiablePublicRegistries,
+      )
       logger.debug('Trust registry resolved', { trustRegistry, schemaId, outcome, hasAdapter: !!adapter })
 
       if (!issuer || !issuanceDate)
@@ -549,18 +549,10 @@ async function processCredential(
 
       // Validate the credential subject attributes against the JSON schema content
       validateSchemaContent(subjectSchema, attrs)
-      let schemaType = identifySchema(subjectSchema)
-      if (schemaType && ecsEcosystems) {
-        const allowed = await ecsEcosystemAllows(
-          ecsEcosystems,
-          registryId,
-          registryBaseUrl,
-          schemaId,
-          adapter,
-          logger,
-        )
-        if (!allowed) schemaType = null
-      }
+      const schemaType = await identifySchema(
+        subjectSchema,
+        ecsEcosystems ? { ecsEcosystems, schemaId, vprId, adapter, logger } : undefined,
+      )
       const source = sourceCredential ?? w3cCredential
       const credential = {
         schemaType,
@@ -724,36 +716,6 @@ function aggregateCredentialFailures(reasons: unknown[]): TrustError {
     first instanceof Error ? first.message : String(first),
     failedCredentials,
   )
-}
-
-async function ecsEcosystemAllows(
-  ecsEcosystems: EcsEcosystem[],
-  registryId: string | undefined,
-  registryBaseUrl: string | undefined,
-  schemaId: string,
-  adapter: IRegistryAdapter | undefined,
-  logger: IVerreLogger,
-): Promise<boolean> {
-  if (!registryId || !registryBaseUrl) return false
-  try {
-    const ecosystemDid = adapter?.fetchSchemaEcosystemDid
-      ? await adapter.fetchSchemaEcosystemDid(schemaId)
-      : await fetchEcosystemDid(registryBaseUrl, schemaId)
-    return !!ecosystemDid && ecsEcosystems.some(e => e.did === ecosystemDid && e.vpr === registryId)
-  } catch {
-    logger.warn('Failed to resolve schema ecosystem, treating as not allowlisted', { schemaId })
-    return false
-  }
-}
-
-async function fetchEcosystemDid(registryBaseUrl: string, schemaId: string): Promise<string | undefined> {
-  const base = toIndexerUrl(registryBaseUrl.replace(/\/$/, ''))
-  const { schema } = await fetchJson<{ schema?: { tr_id?: number } }>(`${base}/cs/v1/get/${schemaId}`)
-  if (!Number.isInteger(schema?.tr_id)) return undefined
-  const { trust_registry } = await fetchJson<{ trust_registry?: { did?: string } }>(
-    `${base}/tr/v1/get/${schema?.tr_id}`,
-  )
-  return trust_registry?.did
 }
 
 /**

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -10,6 +10,7 @@ import { DIDDocument, Resolver, Service } from 'did-resolver'
 import { resolverInstance } from '../libraries/index.js'
 import {
   ECS,
+  EcsEcosystem,
   IRegistryAdapter,
   ResolverConfig,
   TrustResolution,
@@ -127,12 +128,13 @@ export async function resolveCredential(
 ): Promise<CredentialResolution> {
   const logger = options.logger ?? new VerreLogger(LogLevel.NONE)
   try {
-    const { verifiablePublicRegistries, skipDigestSRICheck } = options
+    const { verifiablePublicRegistries, skipDigestSRICheck, ecsEcosystems } = options
     const { credential: w3cCredential, outcome } = await processCredential(
       credential,
       verifiablePublicRegistries ?? [],
       skipDigestSRICheck,
       logger,
+      ecsEcosystems,
     )
     return { verified: true, outcome, issuer: w3cCredential.issuer }
   } catch (error) {
@@ -160,6 +162,8 @@ function resolveTrustRegistry(
   outcome: TrustResolutionOutcome
   schemaUrl: string
   adapter?: IRegistryAdapter
+  registryId?: string
+  registryBaseUrl?: string
 } {
   const registry = verifiablePublicRegistries?.find(registry => refUrl.startsWith(registry.id))
   const schemaUrl =
@@ -178,6 +182,8 @@ function resolveTrustRegistry(
     outcome,
     schemaUrl,
     adapter: registry?.adapter,
+    registryId: registry?.id,
+    registryBaseUrl: registry?.baseUrls[0],
   }
 }
 
@@ -259,7 +265,7 @@ async function processDidDocument(
   if (!didDocument?.service) {
     throw new TrustError(TrustErrorCode.NOT_FOUND, 'Failed to retrieve DID Document with service.')
   }
-  const { verifiablePublicRegistries, didResolver, attrs, skipDigestSRICheck } = options
+  const { verifiablePublicRegistries, didResolver, attrs, skipDigestSRICheck, ecsEcosystems } = options
 
   const credentials: ICredential[] = []
   let serviceProvider: ICredential | undefined
@@ -288,6 +294,7 @@ async function processDidDocument(
           logger,
           didResolver,
           skipDigestSRICheck,
+          ecsEcosystems,
         )
         credentials.push(credential)
         outcome = vpOutcome
@@ -297,13 +304,7 @@ async function processDidDocument(
 
         if (isServiceCred && isExternalIssuer) {
           logger.debug('Processing external issuer service credential', { issuer: credential.issuer })
-          const resolution = await _resolve(credential.issuer, {
-            verifiablePublicRegistries,
-            didResolver,
-            attrs: credential,
-            skipDigestSRICheck,
-            cache: options.cache,
-          })
+          const resolution = await _resolve(credential.issuer, { ...options, attrs: credential })
           service = resolution.service
           serviceProvider = resolution.serviceProvider
         }
@@ -384,6 +385,7 @@ async function getVerifiedCredential(
   logger: IVerreLogger,
   didResolver: Resolver,
   skipDigestSRICheck?: boolean,
+  ecsEcosystems?: EcsEcosystem[],
 ): Promise<{ credential: ICredential; outcome: TrustResolutionOutcome }> {
   logger.debug('Verifying credential', { vp })
 
@@ -407,7 +409,13 @@ async function getVerifiedCredential(
 
   logger.debug('Credential verified successfully')
   try {
-    return await processCredential(w3cCredential, verifiablePublicRegistries, skipDigestSRICheck, logger)
+    return await processCredential(
+      w3cCredential,
+      verifiablePublicRegistries,
+      skipDigestSRICheck,
+      logger,
+      ecsEcosystems,
+    )
   } catch (error) {
     throw toCredentialFailure(error, w3cCredential)
   }
@@ -469,6 +477,7 @@ async function processCredential(
   verifiablePublicRegistries: VerifiablePublicRegistry[],
   skipDigestSRICheck: boolean = false,
   logger: IVerreLogger,
+  ecsEcosystems?: EcsEcosystem[],
   issuer?: string,
   issuanceDate?: string,
   attrs?: Record<string, string>,
@@ -487,6 +496,7 @@ async function processCredential(
       verifiablePublicRegistries,
       skipDigestSRICheck,
       logger,
+      ecsEcosystems,
       w3cCredential.issuer as string,
       w3cCredential.issuanceDate as string,
       subject as Record<string, string>,
@@ -501,10 +511,8 @@ async function processCredential(
     try {
       // Extract the reference URL from the subject if it contains a JSON Schema reference
       const refUrl = getRefUrl(subject)
-      const { trustRegistry, schemaId, outcome, schemaUrl, adapter } = resolveTrustRegistry(
-        refUrl,
-        verifiablePublicRegistries,
-      )
+      const { trustRegistry, schemaId, outcome, schemaUrl, adapter, registryId, registryBaseUrl } =
+        resolveTrustRegistry(refUrl, verifiablePublicRegistries)
       logger.debug('Trust registry resolved', { trustRegistry, schemaId, outcome, hasAdapter: !!adapter })
 
       if (!issuer || !issuanceDate)
@@ -541,9 +549,21 @@ async function processCredential(
 
       // Validate the credential subject attributes against the JSON schema content
       validateSchemaContent(subjectSchema, attrs)
+      let schemaType = identifySchema(subjectSchema)
+      if (schemaType && ecsEcosystems) {
+        const allowed = await ecsEcosystemAllows(
+          ecsEcosystems,
+          registryId,
+          registryBaseUrl,
+          schemaId,
+          adapter,
+          logger,
+        )
+        if (!allowed) schemaType = null
+      }
       const source = sourceCredential ?? w3cCredential
       const credential = {
-        schemaType: identifySchema(subjectSchema),
+        schemaType,
         id,
         issuer,
         ...attrs,
@@ -704,6 +724,36 @@ function aggregateCredentialFailures(reasons: unknown[]): TrustError {
     first instanceof Error ? first.message : String(first),
     failedCredentials,
   )
+}
+
+async function ecsEcosystemAllows(
+  ecsEcosystems: EcsEcosystem[],
+  registryId: string | undefined,
+  registryBaseUrl: string | undefined,
+  schemaId: string,
+  adapter: IRegistryAdapter | undefined,
+  logger: IVerreLogger,
+): Promise<boolean> {
+  if (!registryId || !registryBaseUrl) return false
+  try {
+    const ecosystemDid = adapter?.fetchSchemaEcosystemDid
+      ? await adapter.fetchSchemaEcosystemDid(schemaId)
+      : await fetchEcosystemDid(registryBaseUrl, schemaId)
+    return !!ecosystemDid && ecsEcosystems.some(e => e.did === ecosystemDid && e.vpr === registryId)
+  } catch {
+    logger.warn('Failed to resolve schema ecosystem, treating as not allowlisted', { schemaId })
+    return false
+  }
+}
+
+async function fetchEcosystemDid(registryBaseUrl: string, schemaId: string): Promise<string | undefined> {
+  const base = toIndexerUrl(registryBaseUrl.replace(/\/$/, ''))
+  const { schema } = await fetchJson<{ schema?: { tr_id?: number } }>(`${base}/cs/v1/get/${schemaId}`)
+  if (!Number.isInteger(schema?.tr_id)) return undefined
+  const { trust_registry } = await fetchJson<{ trust_registry?: { did?: string } }>(
+    `${base}/tr/v1/get/${schema?.tr_id}`,
+  )
+  return trust_registry?.did
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,12 @@ export type ResolverConfig = {
   cache?: TrustResolutionCache<string, Promise<TrustResolution>>
   skipDigestSRICheck?: boolean
   logger?: IVerreLogger
+  ecsEcosystems?: EcsEcosystem[]
+}
+
+export type EcsEcosystem = {
+  did: string
+  vpr: string
 }
 
 export type VerifyPermissionsOptions = {
@@ -70,6 +76,10 @@ export interface IRegistryAdapter {
   ): Promise<
     Pick<Permission, 'type' | 'created' | 'effective_from' | 'effective_until' | 'revoked'> | undefined
   >
+  /**
+   * Resolves the DID of the Ecosystem owning a schema. Used for the WL-ECS allowlist.
+   */
+  fetchSchemaEcosystemDid?(schemaId: string): Promise<string | undefined>
 }
 
 export type VerifiablePublicRegistry = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,9 +77,9 @@ export interface IRegistryAdapter {
     Pick<Permission, 'type' | 'created' | 'effective_from' | 'effective_until' | 'revoked'> | undefined
   >
   /**
-   * Resolves the DID of the Ecosystem owning a schema. Used for the WL-ECS allowlist.
+   * Resolves the DID of the Ecosystem that created a schema, for the [WL-ECS] whitelist.
    */
-  fetchSchemaEcosystemDid?(schemaId: string): Promise<string | undefined>
+  fetchSchemaEcosystemDid(schemaId: string): Promise<string | undefined>
 }
 
 export type VerifiablePublicRegistry = {

--- a/src/utils/validateSchema.ts
+++ b/src/utils/validateSchema.ts
@@ -9,7 +9,7 @@ const canonicalize = ((_canonicalize as any).default ?? _canonicalize) as (
   input: unknown,
 ) => string | undefined
 
-import { ECS, TrustErrorCode } from '../types.js'
+import { ECS, EcsEcosystem, IRegistryAdapter, IVerreLogger, TrustErrorCode } from '../types.js'
 
 import { hash } from './crypto.js'
 import { TrustError } from './trustError.js'
@@ -41,22 +41,60 @@ function computeSchemaDigest(schemaObj: Record<string, unknown>): string {
 }
 
 /**
+ * [WL-ECS] provenance of a schema: which Ecosystem created it, and in which VPR.
+ */
+export type EcsProvenance = {
+  ecsEcosystems: EcsEcosystem[]
+  schemaId: string
+  vprId?: string
+  adapter?: IRegistryAdapter
+  logger?: IVerreLogger
+}
+
+/**
  * Identifies the appropriate schema for a given verifiable presentation (VP).
  *
- * Uses digest to validate the schemaObj against ECS schemas
+ * Uses digest to validate the schemaObj against ECS schemas. When `provenance` is given, a
+ * digest match is only an ECS if the Ecosystem that created the schema is whitelisted
+ * ([WL-ECS]); otherwise the credential degrades to a regular VTC.
  *
  * @param schemaObj - The schema to check.
+ * @param provenance - Optional [WL-ECS] context. Omitted, any Ecosystem is accepted.
  * @returns The matching schema name or `null` if no match is found.
  */
-export const identifySchema = (schemaObj: Record<string, unknown>): ECS | null => {
+export const identifySchema = async (
+  schemaObj: Record<string, unknown>,
+  provenance?: EcsProvenance,
+): Promise<ECS | null> => {
   const actualDigest = computeSchemaDigest(schemaObj)
 
   for (const [schemaName, refDigest] of Object.entries(ECS_SCHEMA_DIGESTS) as [ECS, string][]) {
     if (refDigest === actualDigest) {
+      if (provenance && !(await isWhitelistedEcsEcosystem(provenance))) return null
       return schemaName
     }
   }
   return null
+}
+
+async function isWhitelistedEcsEcosystem({
+  ecsEcosystems,
+  schemaId,
+  vprId,
+  adapter,
+  logger,
+}: EcsProvenance): Promise<boolean> {
+  if (!vprId || !adapter?.fetchSchemaEcosystemDid) {
+    logger?.warn('Cannot resolve the Ecosystem of a schema, treating it as not whitelisted', { schemaId })
+    return false
+  }
+  try {
+    const ecosystemDid = await adapter.fetchSchemaEcosystemDid(schemaId)
+    return !!ecosystemDid && ecsEcosystems.some(e => e.did === ecosystemDid && e.vpr === vprId)
+  } catch {
+    logger?.warn('Failed to resolve the Ecosystem of a schema, treating it as not whitelisted', { schemaId })
+    return false
+  }
 }
 
 /**

--- a/src/utils/validateSchema.ts
+++ b/src/utils/validateSchema.ts
@@ -84,9 +84,12 @@ async function isWhitelistedEcsEcosystem({
   adapter,
   logger,
 }: EcsProvenance): Promise<boolean> {
-  if (!vprId || !adapter?.fetchSchemaEcosystemDid) {
-    logger?.warn('Cannot resolve the Ecosystem of a schema, treating it as not whitelisted', { schemaId })
-    return false
+  if (!vprId) return false
+  if (!adapter) {
+    throw new TrustError(
+      TrustErrorCode.INVALID_REQUEST,
+      'ecsEcosystems requires a registry adapter to resolve the Ecosystem that created a schema',
+    )
   }
   try {
     const ecosystemDid = await adapter.fetchSchemaEcosystemDid(schemaId)

--- a/src/utils/validateSchema.ts
+++ b/src/utils/validateSchema.ts
@@ -40,9 +40,6 @@ function computeSchemaDigest(schemaObj: Record<string, unknown>): string {
   return `sha384-${digest}`
 }
 
-/**
- * [WL-ECS] provenance of a schema: which Ecosystem created it, and in which VPR.
- */
 export type EcsProvenance = {
   ecsEcosystems: EcsEcosystem[]
   schemaId: string

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -11,6 +11,8 @@ import {
   TrustResolutionOutcome,
 } from '../../src'
 import { resolverInstance } from '../../src/libraries'
+import { InMemoryCache } from '../../src/utils/helper'
+import { identifySchema } from '../../src/utils/validateSchema'
 import * as signatureVerifier from '../../src/utils/verifier'
 import {
   createRegistriesWithAdapter,
@@ -376,6 +378,46 @@ describe('DidValidator', () => {
       resolverInstance.clear()
     })
 
+    const registriesForEcosystem = (ecosystemDid: string) =>
+      createRegistriesWithAdapter({
+        fetchSchema: async (url: string) => {
+          if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
+          if (url.includes('12345671')) return JSON.stringify(mockCredentialSchemaOrg)
+          throw new Error(`Unexpected schema URL in adapter: ${url}`)
+        },
+        fetchPermission: async () => ({
+          type: PermissionType.ISSUER,
+          created: '2000-11-18T15:26:01.487Z',
+        }),
+        fetchSchemaEcosystemDid: async () => ecosystemDid,
+      })
+
+    const allowlistMockResponses = {
+      'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+      'https://example.com/vp-ser-ext-issued': { ok: true, status: 200, data: mockServiceExtIssuerVc },
+      'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+      'https://ecs-trust-registry/service-credential-schema-credential.json': {
+        ok: true,
+        status: 200,
+        data: mockServiceSchemaSelfIssued,
+      },
+      'https://ecs-trust-registry/service-ext-issuer-credential-schema-credential.json': {
+        ok: true,
+        status: 200,
+        data: mockServiceSchemaExtIssuer,
+      },
+      'https://ecs-trust-registry/org-credential-schema-credential.json': {
+        ok: true,
+        status: 200,
+        data: mockOrgSchema,
+      },
+      'https://www.w3.org/ns/credentials/json-schema/v2.json': {
+        ok: true,
+        status: 200,
+        data: mockW3cJsonSchemaV2,
+      },
+    }
+
     it('should call adapter methods instead of HTTP for schema and permission', async () => {
       vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
         return mockResolversByDid[did]
@@ -519,6 +561,41 @@ describe('DidValidator', () => {
         ecsEcosystems: [trusted],
       })
       expect(deniedExternal.serviceProvider).toBeUndefined()
+    })
+
+    it('does not serve a cached resolution to a caller using a different whitelist', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+      fetchMocker.setMockResponses(allowlistMockResponses)
+
+      const cache = new InMemoryCache()
+      const registries = registriesForEcosystem('did:example:rogue')
+
+      const open = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registries,
+        skipDigestSRICheck: true,
+        cache,
+      })
+      expect(open.verified).toBe(true)
+
+      const restricted = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registries,
+        skipDigestSRICheck: true,
+        cache,
+        ecsEcosystems: [{ did: 'did:example:ecosystem', vpr: 'https://vpr-hostname/vpr' }],
+      })
+      expect(restricted.verified).toBe(false)
+    })
+
+    it('fails loudly when a whitelist is configured without a registry adapter', async () => {
+      await expect(
+        identifySchema(mockCredentialSchemaSer, {
+          ecsEcosystems: [{ did: 'did:example:ecosystem', vpr: 'https://vpr-hostname/vpr' }],
+          schemaId: '12345678',
+          vprId: 'https://vpr-hostname/vpr',
+        }),
+      ).rejects.toThrow('requires a registry adapter')
     })
   })
 

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -378,7 +378,7 @@ describe('DidValidator', () => {
       resolverInstance.clear()
     })
 
-    const registriesForEcosystem = (ecosystemDid: string) =>
+    const registriesFor = (ecosystemBySchemaId: Record<string, string>) =>
       createRegistriesWithAdapter({
         fetchSchema: async (url: string) => {
           if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
@@ -389,7 +389,7 @@ describe('DidValidator', () => {
           type: PermissionType.ISSUER,
           created: '2000-11-18T15:26:01.487Z',
         }),
-        fetchSchemaEcosystemDid: async () => ecosystemDid,
+        fetchSchemaEcosystemDid: async (schemaId: string) => ecosystemBySchemaId[schemaId],
       })
 
     const allowlistMockResponses = {
@@ -491,45 +491,7 @@ describe('DidValidator', () => {
         return mockResolversByDid[did]
       })
 
-      const registriesFor = (ecosystemBySchemaId: Record<string, string>) =>
-        createRegistriesWithAdapter({
-          fetchSchema: async (url: string) => {
-            if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
-            if (url.includes('12345671')) return JSON.stringify(mockCredentialSchemaOrg)
-            throw new Error(`Unexpected schema URL in adapter: ${url}`)
-          },
-          fetchPermission: async () => ({
-            type: PermissionType.ISSUER,
-            created: '2000-11-18T15:26:01.487Z',
-          }),
-          fetchSchemaEcosystemDid: async (schemaId: string) => ecosystemBySchemaId[schemaId],
-        })
-
-      fetchMocker.setMockResponses({
-        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
-        'https://example.com/vp-ser-ext-issued': { ok: true, status: 200, data: mockServiceExtIssuerVc },
-        'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
-        'https://ecs-trust-registry/service-credential-schema-credential.json': {
-          ok: true,
-          status: 200,
-          data: mockServiceSchemaSelfIssued,
-        },
-        'https://ecs-trust-registry/service-ext-issuer-credential-schema-credential.json': {
-          ok: true,
-          status: 200,
-          data: mockServiceSchemaExtIssuer,
-        },
-        'https://ecs-trust-registry/org-credential-schema-credential.json': {
-          ok: true,
-          status: 200,
-          data: mockOrgSchema,
-        },
-        'https://www.w3.org/ns/credentials/json-schema/v2.json': {
-          ok: true,
-          status: 200,
-          data: mockW3cJsonSchemaV2,
-        },
-      })
+      fetchMocker.setMockResponses(allowlistMockResponses)
 
       const trusted = { did: 'did:example:ecosystem', vpr: 'https://vpr-hostname/vpr' }
 
@@ -570,7 +532,7 @@ describe('DidValidator', () => {
       fetchMocker.setMockResponses(allowlistMockResponses)
 
       const cache = new InMemoryCache()
-      const registries = registriesForEcosystem('did:example:rogue')
+      const registries = registriesFor({ '12345678': 'did:example:rogue', '12345671': 'did:example:rogue' })
 
       const open = await resolveDID(didSelfIssued, {
         verifiablePublicRegistries: registries,

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -443,6 +443,83 @@ describe('DidValidator', () => {
         expect.objectContaining({ schemaId: expect.any(String), did: didSelfIssued }),
       )
     })
+
+    it('classifies ECS only for allowlisted ecosystems, including the external issuer path', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+
+      const registriesFor = (ecosystemBySchemaId: Record<string, string>) =>
+        createRegistriesWithAdapter({
+          fetchSchema: async (url: string) => {
+            if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
+            if (url.includes('12345671')) return JSON.stringify(mockCredentialSchemaOrg)
+            throw new Error(`Unexpected schema URL in adapter: ${url}`)
+          },
+          fetchPermission: async () => ({
+            type: PermissionType.ISSUER,
+            created: '2000-11-18T15:26:01.487Z',
+          }),
+          fetchSchemaEcosystemDid: async (schemaId: string) => ecosystemBySchemaId[schemaId],
+        })
+
+      fetchMocker.setMockResponses({
+        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+        'https://example.com/vp-ser-ext-issued': { ok: true, status: 200, data: mockServiceExtIssuerVc },
+        'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+        'https://ecs-trust-registry/service-credential-schema-credential.json': {
+          ok: true,
+          status: 200,
+          data: mockServiceSchemaSelfIssued,
+        },
+        'https://ecs-trust-registry/service-ext-issuer-credential-schema-credential.json': {
+          ok: true,
+          status: 200,
+          data: mockServiceSchemaExtIssuer,
+        },
+        'https://ecs-trust-registry/org-credential-schema-credential.json': {
+          ok: true,
+          status: 200,
+          data: mockOrgSchema,
+        },
+        'https://www.w3.org/ns/credentials/json-schema/v2.json': {
+          ok: true,
+          status: 200,
+          data: mockW3cJsonSchemaV2,
+        },
+      })
+
+      const trusted = { did: 'did:example:ecosystem', vpr: 'https://vpr-hostname/vpr' }
+
+      const allowed = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesFor({ '12345678': trusted.did, '12345671': trusted.did }),
+        skipDigestSRICheck: true,
+        ecsEcosystems: [trusted],
+      })
+      expect(allowed.verified).toBe(true)
+      expect(allowed.service?.schemaType).toBe(ECS.SERVICE)
+
+      const denied = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesFor({
+          '12345678': 'did:example:rogue',
+          '12345671': 'did:example:rogue',
+        }),
+        skipDigestSRICheck: true,
+        ecsEcosystems: [trusted],
+      })
+      expect(denied.verified).toBe(false)
+
+      // the external issuer is resolved through a nested call: the allowlist must reach it too
+      const deniedExternal = await resolveDID(didExtIssuer, {
+        verifiablePublicRegistries: registriesFor({
+          '12345678': trusted.did,
+          '12345671': 'did:example:rogue',
+        }),
+        skipDigestSRICheck: true,
+        ecsEcosystems: [trusted],
+      })
+      expect(deniedExternal.serviceProvider).toBeUndefined()
+    })
   })
 
   describe('resolver method with fully askar initialized agent', () => {


### PR DESCRIPTION
Closes #116.

Adds `ecsEcosystems` to `ResolverConfig` (`{ did, vpr }` pairs). When set, a schema classifies as ECS only if its owning Ecosystem DID is allowlisted for the matching registry, otherwise the credential is treated as an ordinary VTC. Undefined keeps current behaviour (any ecosystem accepted).

- ecosystem lookup via new optional `IRegistryAdapter.fetchSchemaEcosystemDid`, REST fallback (`cs/v1/get` -> `tr/v1/get`) anchored on the registry's configured base URL, not the credential-supplied ref
- unresolvable provenance counts as not allowlisted
- gate also covers the nested external-issuer resolution, which previously rebuilt the options object by hand and dropped fields

Indexer follow-up: implement `fetchSchemaEcosystemDid` in the embedded adapter and set the allowlist on deployed instances.