### PR TITLE
feat: include expire at time on the outcome

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -344,6 +344,7 @@ async function processDidDocument(
       verified: true,
       service,
       serviceProvider,
+      expiresAtTime: computeExpiresAtTime(service, serviceProvider),
     }
   }
   throw new TrustError(TrustErrorCode.NOT_FOUND, 'Valid serviceProvider and service were not found')
@@ -541,7 +542,7 @@ async function processCredential(
 
       // Schema fetches and participant check share no dependencies — run in parallel
       logger.debug('Fetching schemas and verifying participant in parallel')
-      const [schemaRawText, subjectSchemaRawText] = await Promise.all([
+      const [schemaRawText, subjectSchemaRawText, participantEffectiveUntil] = await Promise.all([
         fetchText(schema.id),
         adapter ? adapter.fetchSchema(schemaUrl) : fetchText(schemaUrl),
         api && schemaId !== undefined
@@ -576,6 +577,8 @@ async function processCredential(
         ...normalizeValidityWindow(source),
         raw: source,
       } as ICredential
+      // Feeds expiresAtTime; keyed on the credential so it survives the external-issuer recursion.
+      if (participantEffectiveUntil) authorizingParticipantExpiry.set(credential, participantEffectiveUntil)
       return { credential, outcome }
     } catch (error) {
       logger.error('Failed to process credential', error)
@@ -646,6 +649,25 @@ function getRefUrl(subject: W3cCredentialSubject): string {
 
 function extractSchema<T>(value?: T | T[]): T | undefined {
   return Array.isArray(value) ? value[0] : value
+}
+
+/** Maps a resolved credential to its authorizing Participant's `effective_until`, off the public shape. */
+const authorizingParticipantExpiry = new WeakMap<object, string>()
+
+/**
+ * Computes `expiresAtTime`: the earliest of the ECS-SERVICE and ECS-ORG/PERSONA validity windows
+ * and their authorizing Participants' `effective_until`. Absent boundaries are skipped; `null` when none.
+ */
+function computeExpiresAtTime(service: IService, serviceProvider: ICredential): string | null {
+  const boundaries = [
+    service.validUntil,
+    authorizingParticipantExpiry.get(service),
+    serviceProvider.validUntil,
+    authorizingParticipantExpiry.get(serviceProvider),
+  ].filter((b): b is string => typeof b === 'string' && !Number.isNaN(Date.parse(b)))
+
+  if (boundaries.length === 0) return null
+  return boundaries.reduce((earliest, b) => (Date.parse(b) < Date.parse(earliest) ? b : earliest))
 }
 
 /**
@@ -735,6 +757,8 @@ function aggregateCredentialFailures(reasons: unknown[]): TrustError {
 /**
  * Verifies that an entity is an authorized Participant for the specified schema
  * and ensures the credential's issuance date is not earlier than the Participant creation date.
+ *
+ * @returns The authorized Participant's `effective_until`, or `undefined` when it has no expiry.
  */
 async function verifyAuthorization(
   api: string,
@@ -744,7 +768,7 @@ async function verifyAuthorization(
   role: ParticipantRole,
   logger: IVerreLogger,
   adapter?: IRegistryAdapter,
-) {
+): Promise<string | undefined> {
   logger.debug('Verifying participant', { schemaId, did, hasAdapter: !!adapter })
 
   let participants: Pick<
@@ -792,4 +816,5 @@ async function verifyAuthorization(
     )
 
   logger.debug('Participant verified successfully', { did, schemaId })
+  return authorized.effective_until ?? undefined
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type TrustResolution = {
   didDocument?: DIDDocument
   verified: boolean
   outcome: TrustResolutionOutcome
+  expiresAtTime?: string | null
   metadata?: TrustResolutionMetadata
   service?: IService
   serviceProvider?: ICredential

--- a/tests/integration/network.test.ts
+++ b/tests/integration/network.test.ts
@@ -134,8 +134,6 @@ describe('Integration with Verana Blockchain', () => {
       }),
     )
 
-    // The fixture participants carry no effective_until, so the credentials' validUntil
-    // (VC 1.1 expirationDate 2099-01-01) is the only EVAL-2 boundary.
     expect(result.expiresAtTime).toBe('2099-01-01T00:00:00Z')
 
     // Second call should be served entirely from cache: no new fetch calls

--- a/tests/integration/network.test.ts
+++ b/tests/integration/network.test.ts
@@ -134,6 +134,10 @@ describe('Integration with Verana Blockchain', () => {
       }),
     )
 
+    // The fixture participants carry no effective_until, so the credentials' validUntil
+    // (VC 1.1 expirationDate 2099-01-01) is the only EVAL-2 boundary.
+    expect(result.expiresAtTime).toBe('2099-01-01T00:00:00Z')
+
     // Second call should be served entirely from cache: no new fetch calls
     const fetchCountBefore = (global.fetch as any).mock.calls.length
     const cachedResult = await resolveDID(did, {

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -666,7 +666,6 @@ describe('DidValidator', () => {
       },
     }
 
-    // A self-issued registry whose Participant carries the given `effective_until`.
     const registriesWithParticipantExpiry = (effectiveUntil?: string) =>
       createRegistriesWithAdapter({
         fetchSchema: async (url: string) => {
@@ -683,8 +682,6 @@ describe('DidValidator', () => {
         fetchSchemaEcosystemDid: async () => 'did:example:ecosystem',
       })
 
-    // Both mock credentials carry expirationDate = now + 5y (VC 1.1); the participant boundary is
-    // what we vary to make one side win the `min`.
     const credentialValidUntil = mockServiceVcSelfIssued.verifiableCredential[0].expirationDate as string
 
     it('takes the participant effective_until when it is earlier than the credential validUntil', async () => {
@@ -722,8 +719,6 @@ describe('DidValidator', () => {
     })
 
     it('is null when no credential nor participant boundary exists', async () => {
-      // Clone the VPs without an expirationDate so the credential contributes no validUntil,
-      // and give the participant no effective_until either.
       const stripExpiry = (vp: any) => {
         const clone = structuredClone(vp)
         delete clone.verifiableCredential[0].expirationDate

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -632,6 +632,123 @@ describe('DidValidator', () => {
     })
   })
 
+  describe('expiresAtTime (IDX-VT-EVAL-2)', () => {
+    beforeEach(() => {
+      vi.spyOn(signatureVerifier, 'verifySignature').mockResolvedValue({ result: true })
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(
+        async (did: string) => mockResolversByDid[did],
+      )
+      fetchMocker.enable()
+    })
+
+    afterEach(() => {
+      fetchMocker.reset()
+      fetchMocker.disable()
+      vi.clearAllMocks()
+      resolverInstance.clear()
+    })
+
+    const schemaResponses = {
+      'https://ecs-trust-registry/service-credential-schema-credential.json': {
+        ok: true,
+        status: 200,
+        data: mockServiceSchemaSelfIssued,
+      },
+      'https://ecs-trust-registry/org-credential-schema-credential.json': {
+        ok: true,
+        status: 200,
+        data: mockOrgSchema,
+      },
+      'https://www.w3.org/ns/credentials/json-schema/v2.json': {
+        ok: true,
+        status: 200,
+        data: mockW3cJsonSchemaV2,
+      },
+    }
+
+    // A self-issued registry whose Participant carries the given `effective_until`.
+    const registriesWithParticipantExpiry = (effectiveUntil?: string) =>
+      createRegistriesWithAdapter({
+        fetchSchema: async (url: string) => {
+          if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
+          if (url.includes('12345671')) return JSON.stringify(mockCredentialSchemaOrg)
+          throw new Error(`Unexpected schema URL in adapter: ${url}`)
+        },
+        fetchParticipant: async () => ({
+          role: ParticipantRole.ISSUER,
+          created: '2000-11-18T15:26:01.487Z',
+          participant_state: ParticipantState.ACTIVE,
+          ...(effectiveUntil ? { effective_until: effectiveUntil } : {}),
+        }),
+        fetchSchemaEcosystemDid: async () => 'did:example:ecosystem',
+      })
+
+    // Both mock credentials carry expirationDate = now + 5y (VC 1.1); the participant boundary is
+    // what we vary to make one side win the `min`.
+    const credentialValidUntil = mockServiceVcSelfIssued.verifiableCredential[0].expirationDate as string
+
+    it('takes the participant effective_until when it is earlier than the credential validUntil', async () => {
+      const earlyBoundary = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString() // now + 1y
+      fetchMocker.setMockResponses({
+        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+        'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+        ...schemaResponses,
+      })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithParticipantExpiry(earlyBoundary),
+        skipDigestSRICheck: true,
+      })
+
+      expect(result.verified).toBe(true)
+      expect(result.expiresAtTime).toBe(earlyBoundary)
+    })
+
+    it('takes the credential validUntil (VC 1.1 expirationDate) when it is earlier than the participant', async () => {
+      const lateBoundary = new Date(Date.now() + 20 * 365 * 24 * 60 * 60 * 1000).toISOString() // now + 20y
+      fetchMocker.setMockResponses({
+        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: mockServiceVcSelfIssued },
+        'https://example.com/vp-org': { ok: true, status: 200, data: mockOrgVc },
+        ...schemaResponses,
+      })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithParticipantExpiry(lateBoundary),
+        skipDigestSRICheck: true,
+      })
+
+      expect(result.verified).toBe(true)
+      expect(result.expiresAtTime).toBe(credentialValidUntil)
+    })
+
+    it('is null when no credential nor participant boundary exists', async () => {
+      // Clone the VPs without an expirationDate so the credential contributes no validUntil,
+      // and give the participant no effective_until either.
+      const stripExpiry = (vp: any) => {
+        const clone = structuredClone(vp)
+        delete clone.verifiableCredential[0].expirationDate
+        return clone
+      }
+      fetchMocker.setMockResponses({
+        'https://example.com/vp-ser-self-issued': {
+          ok: true,
+          status: 200,
+          data: stripExpiry(mockServiceVcSelfIssued),
+        },
+        'https://example.com/vp-org': { ok: true, status: 200, data: stripExpiry(mockOrgVc) },
+        ...schemaResponses,
+      })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesWithParticipantExpiry(undefined),
+        skipDigestSRICheck: true,
+      })
+
+      expect(result.verified).toBe(true)
+      expect(result.expiresAtTime).toBeNull()
+    })
+  })
+
   describe('resolver method with fully askar initialized agent', () => {
     it('should resolve a did:web using an agent with Askar in-memory wallet', async () => {
       const agent = await setupAgent({ name: 'InMemoryTestAgent' })


### PR DESCRIPTION
**Changes**

* Update the outcome to include the `expiresAtTime` field to address this issue: https://github.com/verana-labs/verana-indexer/pull/383/
