### PR TITLE
feat!: trust resolution according to v4 spec

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -348,12 +348,20 @@ async function processDidDocument(
           ecsEcosystems,
         )
         credentials.push(credential)
+        const carried = await resolveCarriedCredentials(
+          vp,
+          credential.id,
+          verifiablePublicRegistries ?? [],
+          logger,
+          skipDigestSRICheck,
+          ecsEcosystems,
+        )
         presentations.push({
           serviceId: id,
           endpoint: firstEndpoint(didService),
-          credentials: [credential],
-          unresolvableCredentialIds: [],
-          invalidCredentialIds: [],
+          credentials: [credential, ...carried.credentials],
+          unresolvableCredentialIds: carried.unresolvableCredentialIds,
+          invalidCredentialIds: carried.invalidCredentialIds,
         })
         outcome = vpOutcome
 
@@ -388,7 +396,7 @@ async function processDidDocument(
       service,
       serviceProvider,
       ...(anchorPattern ? { anchorPattern } : {}),
-      // boundary over the anchor credentials only
+
       expiresAtTime: earliestBoundary([
         service.validUntil,
         serviceProvider.validUntil,
@@ -525,6 +533,59 @@ function getCredential(vp: W3cPresentation): W3cVerifiableCredential {
 }
 
 /**
+ * Resolves the credentials a VP carries beyond the one driving the verdict. keeps
+ * these out of `trusted`/`expiresAtTime`, so a failure here only classifies the credential —
+ * unresolvable (no trust chain) or invalid (structurally) — and never fails the resolution.
+ */
+async function resolveCarriedCredentials(
+  vp: W3cPresentation,
+  primaryId: string,
+  verifiablePublicRegistries: VerifiablePublicRegistry[],
+  logger: IVerreLogger,
+  skipDigestSRICheck?: boolean,
+  ecsEcosystems?: EcsEcosystem[],
+): Promise<Pick<PresentationSummary, 'credentials' | 'unresolvableCredentialIds' | 'invalidCredentialIds'>> {
+  const all = Array.isArray(vp.verifiableCredential)
+    ? vp.verifiableCredential
+    : vp.verifiableCredential
+      ? [vp.verifiableCredential]
+      : []
+  const carried = all.filter(vc => vc.type?.includes('VerifiableCredential') && vc.id !== primaryId)
+
+  const credentials: ResolvedCredential[] = []
+  const unresolvableCredentialIds: string[] = []
+  const invalidCredentialIds: string[] = []
+
+  await Promise.all(
+    carried.map(async vc => {
+      const vcId = typeof vc.id === 'string' ? vc.id : ''
+      try {
+        const { credential } = await processCredential(
+          vc,
+          verifiablePublicRegistries,
+          skipDigestSRICheck,
+          logger,
+          ecsEcosystems,
+        )
+        credentials.push(credential)
+      } catch (error) {
+        const code = error instanceof TrustError ? error.metadata.errorCode : undefined
+        // no trust chain vs structurally invalid
+        const unresolvable =
+          code === TrustErrorCode.NOT_SUPPORTED ||
+          code === TrustErrorCode.NOT_FOUND ||
+          code === TrustErrorCode.NOT_AUTHORIZED ||
+          code === TrustErrorCode.NO_ANCHORED_DIGEST ||
+          code === TrustErrorCode.INVALID_REQUEST
+        ;(unresolvable ? unresolvableCredentialIds : invalidCredentialIds).push(vcId)
+      }
+    }),
+  )
+
+  return { credentials, unresolvableCredentialIds, invalidCredentialIds }
+}
+
+/**
  * Processes and validates a Verifiable Credential against its declared schema.
  *
  * This function supports two schema types:
@@ -646,7 +707,6 @@ async function processCredential(
         if (version) evidence.ecsSchemaVersion = version
         evidence.issuerParticipant = toParticipantRef(issuerParticipant)
 
-        // HOLDER entries anchoring the credential
         const subjectDid = typeof attrs?.id === 'string' ? attrs.id : undefined
         if (subjectDid) {
           // a credential with no anchoring entry contributes no boundary, not a failure

--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -15,10 +15,9 @@ import {
   ResolverConfig,
   TrustResolution,
   TrustErrorCode,
-  IService,
-  ICredential,
-  IOrg,
-  IPersona,
+  ResolvedCredential,
+  PresentationSummary,
+  ParticipantRef,
   InternalResolverConfig,
   VerifiablePublicRegistry,
   TrustResolutionOutcome,
@@ -48,13 +47,26 @@ import {
 } from '../utils/index.js'
 
 type CredentialResult = {
-  credential: ICredential
+  credential: ResolvedCredential
   outcome: TrustResolutionOutcome
-  participantEffectiveUntils?: Array<string | null | undefined>
 }
 
-// [IDX-VT-EVAL-2] the trust verdict flips at the earliest of the anchor credentials' validUntil and
-// their anchoring Participants' effective_until. Never a duration from the evaluation instant.
+/** Maps an indexed Participant to the trimmed reference verre exposes as evidence. */
+function toParticipantRef(
+  participant: Pick<
+    Participant,
+    'id' | 'role' | 'created' | 'effective_from' | 'effective_until' | 'participant_state'
+  >,
+): ParticipantRef {
+  return {
+    id: participant.id,
+    role: participant.role,
+    ...(participant.effective_from ? { effectiveFrom: participant.effective_from } : {}),
+    ...(participant.effective_until ? { effectiveUntil: participant.effective_until } : {}),
+    ...(participant.participant_state ? { state: participant.participant_state } : {}),
+  }
+}
+
 export function earliestBoundary(values: Array<string | null | undefined>): string | null {
   const times = values
     .filter((value): value is string => typeof value === 'string' && value.length > 0)
@@ -186,6 +198,7 @@ function resolveSchemaRef(
   schemaUrl: string
   adapter?: IRegistryAdapter
   vpr?: string
+  version?: string
 } {
   const parsed = /^(vpr:[^:]+:[^:]+):cs:(\d+)$/.exec(ref)
   if (parsed) {
@@ -202,6 +215,7 @@ function resolveSchemaRef(
       schemaUrl: `${api}/v4/credential-schema/js/${schemaId}`,
       adapter: registry.adapter,
       vpr: registry.scheme,
+      version: registry.version,
     }
   }
 
@@ -301,11 +315,12 @@ async function processDidDocument(
   }
   const { verifiablePublicRegistries, didResolver, attrs, skipDigestSRICheck, ecsEcosystems } = options
 
-  const credentials: ICredential[] = []
-  let serviceProvider: ICredential | undefined
-  let service: IService | undefined = attrs
+  const credentials: ResolvedCredential[] = []
+  const presentations: PresentationSummary[] = []
+  let serviceProvider: ResolvedCredential | undefined
+  let service: ResolvedCredential | undefined = attrs
   let outcome: TrustResolutionOutcome = TrustResolutionOutcome.NOT_TRUSTED
-  const participantBoundaries = new Map<ICredential, Array<string | null | undefined>>()
+  let anchorPattern: 'self' | 'parent' | undefined
   let delegatedExpiresAtTime: string | null | undefined
 
   logger.debug('Processing DID services', { serviceCount: didDocument.service.length })
@@ -324,11 +339,7 @@ async function processDidDocument(
           )
 
         logger.debug('Getting verified credential from VP', { id })
-        const {
-          credential,
-          outcome: vpOutcome,
-          participantEffectiveUntils,
-        } = await getVerifiedCredential(
+        const { credential, outcome: vpOutcome } = await getVerifiedCredential(
           vp,
           verifiablePublicRegistries ?? [],
           logger,
@@ -337,11 +348,19 @@ async function processDidDocument(
           ecsEcosystems,
         )
         credentials.push(credential)
-        participantBoundaries.set(credential, participantEffectiveUntils ?? [])
+        presentations.push({
+          serviceId: id,
+          endpoint: firstEndpoint(didService),
+          credentials: [credential],
+          unresolvableCredentialIds: [],
+          invalidCredentialIds: [],
+        })
         outcome = vpOutcome
 
-        const isServiceCred = credential.schemaType === ECS.SERVICE
+        const isServiceCred = credential.ecs === ECS.SERVICE
         const isExternalIssuer = credential.issuer !== did
+
+        if (isServiceCred) anchorPattern = isExternalIssuer ? 'parent' : 'self'
 
         if (isServiceCred && isExternalIssuer) {
           logger.debug('Processing external issuer service credential', { issuer: credential.issuer })
@@ -357,10 +376,8 @@ async function processDidDocument(
   const reasons = serviceResults.flatMap(result => (result.status === 'rejected' ? [result.reason] : []))
   if (reasons.length > 0) throw aggregateCredentialFailures(reasons)
 
-  service ??= credentials.find((cred): cred is IService => cred.schemaType === ECS.SERVICE)
-  serviceProvider ??= credentials.find(
-    (cred): cred is IOrg | IPersona => cred.schemaType === ECS.ORG || cred.schemaType === ECS.PERSONA,
-  )
+  service ??= credentials.find(cred => cred.ecs === ECS.SERVICE)
+  serviceProvider ??= credentials.find(cred => cred.ecs === ECS.ORG || cred.ecs === ECS.PERSONA)
 
   // If proof of trust exists, return the result with the service (issuer equals did)
   if (serviceProvider && service) {
@@ -370,16 +387,27 @@ async function processDidDocument(
       verified: true,
       service,
       serviceProvider,
+      ...(anchorPattern ? { anchorPattern } : {}),
+      // boundary over the anchor credentials only
       expiresAtTime: earliestBoundary([
         service.validUntil,
         serviceProvider.validUntil,
-        ...(participantBoundaries.get(service) ?? []),
-        ...(participantBoundaries.get(serviceProvider) ?? []),
+        ...service.subjectParticipants.map(participant => participant.effectiveUntil),
+        ...serviceProvider.subjectParticipants.map(participant => participant.effectiveUntil),
         delegatedExpiresAtTime,
       ]),
+      presentations,
     }
   }
   throw new TrustError(TrustErrorCode.NOT_FOUND, 'Valid serviceProvider and service were not found')
+}
+
+/** The first serviceEndpoint of a DID service, as a string (for evidence). */
+function firstEndpoint(service: Service): string {
+  const endpoint = Array.isArray(service.serviceEndpoint)
+    ? service.serviceEndpoint[0]
+    : service.serviceEndpoint
+  return typeof endpoint === 'string' ? endpoint : ''
 }
 
 /**
@@ -560,7 +588,7 @@ async function processCredential(
     try {
       // Extract the reference URL from the subject if it contains a JSON Schema reference
       const refUrl = getRefUrl(subject)
-      const { api, schemaId, outcome, schemaUrl, adapter, vpr } = resolveSchemaRef(
+      const { api, schemaId, outcome, schemaUrl, adapter, vpr, version } = resolveSchemaRef(
         refUrl,
         verifiablePublicRegistries,
       )
@@ -578,22 +606,30 @@ async function processCredential(
         adapter ? adapter.fetchSchema(schemaUrl) : fetchText(schemaUrl),
       ])
 
-      // [IDX-VT-EVAL-1] the issuance instant must come from the ledger, never from the credential:
-      // an issuer-asserted date can be backdated to a window it was not authorised in
-      let subjectEffectiveUntils: Array<string | null | undefined> = []
+      const source = sourceCredential ?? w3cCredential
+
+      // issuance evidence derived from the ledger digest, not the credential
+      const evidence: Pick<
+        ResolvedCredential,
+        | 'digestJCS'
+        | 'issuedAtTime'
+        | 'issuedAtHeight'
+        | 'credentialSchemaId'
+        | 'ecosystemId'
+        | 'ecsSchemaVersion'
+        | 'issuerParticipant'
+      > = {}
+      let subjectParticipants: ParticipantRef[] = []
       if (api && schemaId !== undefined) {
         const credentialSchema = await resolveCredentialSchema(api, schemaId, adapter)
-        const digestJCS = computeCredentialDigestJCS(
-          (sourceCredential ?? w3cCredential) as W3cVerifiableCredential,
-          credentialSchema.digestAlgorithm,
-        )
+        const digestJCS = computeCredentialDigestJCS(source, credentialSchema.digestAlgorithm)
         const anchored = await resolveAnchoredDigest(api, digestJCS, adapter)
         if (!anchored)
           throw new TrustError(
             TrustErrorCode.NO_ANCHORED_DIGEST,
             `No anchored digest ${digestJCS} was found, the credential has no provable issuance time`,
           )
-        await verifyAuthorization(
+        const issuerParticipant = await verifyAuthorization(
           api,
           schemaId,
           anchored.created,
@@ -602,11 +638,18 @@ async function processCredential(
           logger,
           adapter,
         )
+        evidence.digestJCS = digestJCS
+        evidence.issuedAtTime = anchored.created
+        if (anchored.height !== undefined) evidence.issuedAtHeight = anchored.height
+        evidence.credentialSchemaId = credentialSchema.id
+        evidence.ecosystemId = credentialSchema.ecosystemId
+        if (version) evidence.ecsSchemaVersion = version
+        evidence.issuerParticipant = toParticipantRef(issuerParticipant)
 
-        // [IDX-VT-EVAL-2] minimises over every Participant entry anchoring the credential
+        // HOLDER entries anchoring the credential
         const subjectDid = typeof attrs?.id === 'string' ? attrs.id : undefined
         if (subjectDid) {
-          // a credential with no anchoring entry contributes no boundary, it is not a failure
+          // a credential with no anchoring entry contributes no boundary, not a failure
           const anchoring = await fetchParticipantsAt(
             api,
             schemaId,
@@ -622,7 +665,7 @@ async function processCredential(
             })
             return []
           })
-          subjectEffectiveUntils = anchoring.map(participant => participant.effective_until)
+          subjectParticipants = anchoring.map(toParticipantRef)
         }
       }
 
@@ -638,24 +681,28 @@ async function processCredential(
 
       // Validate the credential subject attributes against the JSON schema content
       validateSchemaContent(subjectSchema, attrs)
-      const schemaType = await identifySchema(
+      const ecs = await identifySchema(
         subjectSchema,
         ecsEcosystems && schemaId !== undefined
           ? { ecsEcosystems, schemaId, vprId: vpr, adapter, logger }
           : undefined,
       )
-      const source = sourceCredential ?? w3cCredential
-      const credential = {
-        schemaType,
-        id,
+      const credential: ResolvedCredential = {
+        ecs,
+        // the VC id, not the subject DID
+        id: (typeof source.id === 'string' ? source.id : undefined) ?? id,
         issuer,
-        ...attrs,
+        subject: (extractSchema((source as any).credentialSubject) ?? attrs ?? {}) as Record<string, unknown>,
         ...normalizeValidityWindow(source),
         raw: source,
-      } as ICredential
-      return { credential, outcome, participantEffectiveUntils: subjectEffectiveUntils }
+        ...evidence,
+        subjectParticipants,
+      }
+      return { credential, outcome }
     } catch (error) {
       logger.error('Failed to process credential', error)
+      // preserve dedicated TrustError codes; only wrap unexpected errors
+      if (error instanceof TrustError) throw error
       throw new TrustError(TrustErrorCode.INVALID, `Failed to validate credential: ${error.message}`)
     }
   }
@@ -865,7 +912,7 @@ async function fetchParticipantsAt(
   >
 > {
   if (adapter) return adapter.listParticipants(schemaId, did, role, when)
-  // `when` narrows to entries effective at issuance, so a later grant cannot shadow the one that covered it
+  // `when` narrows to entries effective at issuance, so a later grant cannot shadow the covering one
   const participantUrl = `${api}/v4/participant/list?did=${encodeURIComponent(
     did,
   )}&role=${role}&schema_id=${schemaId}&when=${encodeURIComponent(when)}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,10 +8,39 @@ export type TrustResolution = {
   verified: boolean
   outcome: TrustResolutionOutcome
   metadata?: TrustResolutionMetadata
-  service?: IService
-  serviceProvider?: ICredential
-  failedCredentials?: FailedCredential[]
+  service?: ResolvedCredential
+  serviceProvider?: ResolvedCredential
+  anchorPattern?: 'self' | 'parent'
   expiresAtTime?: string | null
+  presentations?: PresentationSummary[]
+  failedCredentials?: FailedCredential[]
+}
+
+export type ResolvedCredential = {
+  ecs: ECS | null
+  id: string
+  issuer: string
+  subject: Record<string, unknown>
+  validFrom?: string
+  validUntil?: string
+  raw: W3cVerifiableCredential
+
+  digestJCS?: string
+  issuedAtTime?: string
+  issuedAtHeight?: number
+  credentialSchemaId?: number
+  ecosystemId?: number
+  ecsSchemaVersion?: string
+  issuerParticipant?: ParticipantRef
+  subjectParticipants: ParticipantRef[]
+}
+
+export type PresentationSummary = {
+  serviceId: string
+  endpoint: string
+  credentials: ResolvedCredential[]
+  unresolvableCredentialIds: string[]
+  invalidCredentialIds: string[]
 }
 
 export const CREDENTIAL_FORMAT_LDP_VC = 'ldp_vc'
@@ -54,7 +83,7 @@ export type VerifyParticipantOptions = {
 
 export type InternalResolverConfig = Omit<ResolverConfig, 'didResolver'> & {
   didResolver: Resolver
-  attrs?: IService
+  attrs?: ResolvedCredential
 }
 
 /**

--- a/tests/integration/network.test.ts
+++ b/tests/integration/network.test.ts
@@ -120,16 +120,20 @@ describe('Integration with Verana Blockchain', () => {
         verified: true,
         outcome: TrustResolutionOutcome.VERIFIED_TEST,
         service: expect.objectContaining({
-          schemaType: 'ecs-service',
-          name: 'V4 Demo Service',
-          logoUri: 'https://v4-agent.example/logo.png',
+          ecs: 'ecs-service',
           issuer: did,
+          subject: expect.objectContaining({
+            name: 'V4 Demo Service',
+            logoUri: 'https://v4-agent.example/logo.png',
+          }),
         }),
         serviceProvider: expect.objectContaining({
-          schemaType: 'ecs-org',
-          name: 'V4 Demo Org',
-          registryId: 'REG-1',
+          ecs: 'ecs-org',
           issuer: did,
+          subject: expect.objectContaining({
+            name: 'V4 Demo Org',
+            registryId: 'REG-1',
+          }),
         }),
       }),
     )

--- a/tests/integration/network.test.ts
+++ b/tests/integration/network.test.ts
@@ -135,6 +135,17 @@ describe('Integration with Verana Blockchain', () => {
             registryId: 'REG-1',
           }),
         }),
+        anchorPattern: 'self',
+        expiresAtTime: '2099-01-01T00:00:00.000Z',
+        presentations: expect.arrayContaining([
+          expect.objectContaining({
+            serviceId: `${did}#vpr-schemas-service-vtc-vp`,
+            endpoint: expect.any(String),
+            credentials: expect.arrayContaining([expect.objectContaining({ ecs: 'ecs-service' })]),
+            unresolvableCredentialIds: [],
+            invalidCredentialIds: [],
+          }),
+        ]),
       }),
     )
 

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -151,24 +151,26 @@ describe('DidValidator', () => {
           verified: true,
           outcome: TrustResolutionOutcome.VERIFIED,
           ...mockDidDocumentSelfIssued,
-          service: {
-            schemaType: ECS.SERVICE,
-            id: didSelfIssued,
+          service: expect.objectContaining({
+            ecs: ECS.SERVICE,
+            id: mockServiceVcSelfIssued.verifiableCredential[0].id,
             issuer: didSelfIssued,
-            ...mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
+            subject: expect.objectContaining(
+              mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject,
+            ),
             validFrom: mockServiceVcSelfIssued.verifiableCredential[0].issuanceDate,
             validUntil: mockServiceVcSelfIssued.verifiableCredential[0].expirationDate,
             raw: mockServiceVcSelfIssued.verifiableCredential[0],
-          },
-          serviceProvider: {
-            schemaType: ECS.ORG,
-            id: didSelfIssued,
+          }),
+          serviceProvider: expect.objectContaining({
+            ecs: ECS.ORG,
+            id: mockOrgVc.verifiableCredential[0].id,
             issuer: didSelfIssued,
-            ...mockOrgVc.verifiableCredential[0].credentialSubject,
+            subject: expect.objectContaining(mockOrgVc.verifiableCredential[0].credentialSubject),
             validFrom: mockOrgVc.verifiableCredential[0].issuanceDate,
             validUntil: mockOrgVc.verifiableCredential[0].expirationDate,
             raw: mockOrgVc.verifiableCredential[0],
-          },
+          }),
         }),
       )
     })
@@ -276,24 +278,28 @@ describe('DidValidator', () => {
           verified: true,
           outcome: TrustResolutionOutcome.VERIFIED,
           ...mockDidDocumentSelfIssuedExtIssuer,
-          service: {
-            schemaType: ECS.SERVICE,
-            id: didSelfIssued,
+          service: expect.objectContaining({
+            ecs: ECS.SERVICE,
+            id: mockServiceExtIssuerVc.verifiableCredential[0].id,
             issuer: didSelfIssued,
-            ...mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            subject: expect.objectContaining(
+              mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            ),
             validFrom: mockServiceExtIssuerVc.verifiableCredential[0].issuanceDate,
             validUntil: mockServiceExtIssuerVc.verifiableCredential[0].expirationDate,
             raw: mockServiceExtIssuerVc.verifiableCredential[0],
-          },
-          serviceProvider: {
-            schemaType: ECS.ORG,
-            id: didSelfIssued,
+          }),
+          serviceProvider: expect.objectContaining({
+            ecs: ECS.ORG,
+            id: mockOrgVcWithoutIssuer.verifiableCredential[0].id,
             issuer: didSelfIssued,
-            ...mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            subject: expect.objectContaining(
+              mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            ),
             validFrom: mockOrgVcWithoutIssuer.verifiableCredential[0].issuanceDate,
             validUntil: mockOrgVcWithoutIssuer.verifiableCredential[0].expirationDate,
             raw: mockOrgVcWithoutIssuer.verifiableCredential[0],
-          },
+          }),
         }),
       )
     })
@@ -374,24 +380,28 @@ describe('DidValidator', () => {
           verified: true,
           outcome: TrustResolutionOutcome.VERIFIED,
           ...mockDidDocumentSelfIssuedExtIssuer,
-          service: {
-            schemaType: ECS.SERVICE,
-            id: didSelfIssued,
+          service: expect.objectContaining({
+            ecs: ECS.SERVICE,
+            id: mockServiceExtIssuerVc.verifiableCredential[0].id,
             issuer: didSelfIssued,
-            ...mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            subject: expect.objectContaining(
+              mockServiceExtIssuerVc.verifiableCredential[0].credentialSubject,
+            ),
             validFrom: mockServiceExtIssuerVc.verifiableCredential[0].issuanceDate,
             validUntil: mockServiceExtIssuerVc.verifiableCredential[0].expirationDate,
             raw: mockServiceExtIssuerVc.verifiableCredential[0],
-          },
-          serviceProvider: {
-            schemaType: ECS.ORG,
-            id: didSelfIssued,
+          }),
+          serviceProvider: expect.objectContaining({
+            ecs: ECS.ORG,
+            id: mockOrgVcWithoutIssuer.verifiableCredential[0].id,
             issuer: didSelfIssued,
-            ...mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            subject: expect.objectContaining(
+              mockOrgVcWithoutIssuer.verifiableCredential[0].credentialSubject,
+            ),
             validFrom: mockOrgVcWithoutIssuer.verifiableCredential[0].issuanceDate,
             validUntil: mockOrgVcWithoutIssuer.verifiableCredential[0].expirationDate,
             raw: mockOrgVcWithoutIssuer.verifiableCredential[0],
-          },
+          }),
         }),
       )
 
@@ -570,7 +580,7 @@ describe('DidValidator', () => {
         ecsEcosystems: [trusted],
       })
       expect(allowed.verified).toBe(true)
-      expect(allowed.service?.schemaType).toBe(ECS.SERVICE)
+      expect(allowed.service?.ecs).toBe(ECS.SERVICE)
 
       const denied = await resolveDID(didSelfIssued, {
         verifiablePublicRegistries: registriesFor({
@@ -670,6 +680,50 @@ describe('DidValidator', () => {
 
       expect(result.verified).toBe(false)
       expect(result.metadata?.errorMessage).toContain('no provable issuance time')
+    })
+
+    it('surfaces the VPR evidence on each resolved credential (Scope B)', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+      fetchMocker.setMockResponses({ ...allowlistMockResponses, ...ALL_ANCHOR_MOCKS })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesFor({
+          '12345678': 'did:example:ecosystem',
+          '12345671': 'did:example:ecosystem',
+        }),
+        skipDigestSRICheck: true,
+      })
+
+      expect(result.verified).toBe(true)
+      // the service self-issued this credential
+      expect(result.anchorPattern).toBe('self')
+
+      const service = result.service!
+      // id is the VC id, no longer shadowed by the subject DID
+      expect(service.id).toBe(mockServiceVcSelfIssued.verifiableCredential[0].id)
+      expect(service.subject.id).toBe(mockServiceVcSelfIssued.verifiableCredential[0].credentialSubject.id)
+      expect(service.id).not.toBe(service.subject.id)
+      // EVAL-1 evidence gathered on the way
+      expect(service.digestJCS).toEqual(expect.any(String))
+      expect(service.issuedAtTime).toBe(ANCHORED_AT)
+      expect(service.credentialSchemaId).toEqual(expect.any(Number))
+      expect(service.ecosystemId).toBe(1)
+      expect(service.issuerParticipant).toEqual(
+        expect.objectContaining({ id: 1, role: ParticipantRole.ISSUER }),
+      )
+      expect(Array.isArray(service.subjectParticipants)).toBe(true)
+
+      // the linked VPs are surfaced so consumers do not re-fetch them
+      expect(result.presentations?.length).toBeGreaterThan(0)
+      expect(result.presentations?.[0]).toEqual(
+        expect.objectContaining({
+          serviceId: expect.any(String),
+          endpoint: expect.any(String),
+          credentials: expect.arrayContaining([service]),
+        }),
+      )
     })
 
     it('takes expiresAtTime from the HOLDER entries anchoring the credential', async () => {

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -726,6 +726,48 @@ describe('DidValidator', () => {
       )
     })
 
+    it('surfaces carried credentials and classifies the ones that fail (Scope B)', async () => {
+      const carriedInvalid = {
+        id: 'urn:vc:carried-invalid',
+        type: ['VerifiableCredential', 'ExampleBadge'],
+        issuer: didSelfIssued,
+        issuanceDate: '2024-01-01T00:00:00Z',
+        credentialSchema: { id: 'https://example.com/unsupported', type: 'UnsupportedSchemaType' },
+        credentialSubject: { id: 'did:example:holder' },
+      }
+      const vpWithCarried = {
+        ...mockServiceVcSelfIssued,
+        verifiableCredential: [mockServiceVcSelfIssued.verifiableCredential[0], carriedInvalid],
+      }
+
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+      fetchMocker.setMockResponses({
+        ...allowlistMockResponses,
+        ...ALL_ANCHOR_MOCKS,
+        'https://example.com/vp-ser-self-issued': { ok: true, status: 200, data: vpWithCarried },
+      })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registriesFor({
+          '12345678': 'did:example:ecosystem',
+          '12345671': 'did:example:ecosystem',
+        }),
+        skipDigestSRICheck: true,
+      })
+
+      // the carried failure must not affect the verdict [IDX-VT-EVAL-1]
+      expect(result.verified).toBe(true)
+
+      const servicePresentation = result.presentations?.find(presentation =>
+        presentation.credentials.some(credential => credential.ecs === ECS.SERVICE),
+      )
+      // the primary ECS credential is surfaced alongside the VP's carried contents
+      expect(servicePresentation?.credentials.some(credential => credential.ecs === ECS.SERVICE)).toBe(true)
+      expect(servicePresentation?.invalidCredentialIds).toContain('urn:vc:carried-invalid')
+    })
+
     it('takes expiresAtTime from the HOLDER entries anchoring the credential', async () => {
       vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
         return mockResolversByDid[did]


### PR DESCRIPTION
**Changes**
- Update outcome result over verre
- Surface VPR trust evidence on resolved credentials (Scope B)
- Fix `credential.id` shadowing (VC id, not subject DID)
- Add `anchorPattern`, `expiresAtTime` and `presentations[]`
- Resolve and classify carried credentials per VP
- Preserve dedicated `TrustError` codes in `failedCredentials`
- Extend unit and integration tests
