### PR TITLE
fix: select the active Participant instead of the first one covering the instant

### DIFF
--- a/src/resolver/didValidator.ts
+++ b/src/resolver/didValidator.ts
@@ -1006,28 +1006,32 @@ async function verifyAuthorization(
   participants = await fetchParticipantsAt(api, schemaId, did, role, issuanceDate, adapter)
 
   const issuanceTs = Date.parse(issuanceDate)
-  const authorized = participants.find(participant => {
+  const covering = participants.filter(participant => {
     if (participant.role !== role) return false
     const effectiveFrom = Date.parse(participant.effective_from ?? participant.created)
     const effectiveUntil = participant.effective_until ? Date.parse(participant.effective_until) : Date.now()
     return issuanceTs >= effectiveFrom && issuanceTs <= effectiveUntil
   })
 
-  if (!authorized)
+  if (covering.length === 0)
     throw new TrustError(
       TrustErrorCode.NOT_AUTHORIZED,
       `No ${role} Participant effective at ${issuanceDate} was found for the specified DID: ${did} for schema ${schemaId}`,
     )
 
+  // any covering entry authorises the issuance if usable now; a revoked one must not shadow a usable one.
   // later expiry does not invalidate an already-issued credential, every other state does:
   // REPAID reports a slash that may also mask a revocation, FUTURE and INACTIVE were never effective
-  if (
-    authorized.participant_state !== ParticipantState.ACTIVE &&
-    authorized.participant_state !== ParticipantState.EXPIRED
+  const authorized = covering.find(
+    participant =>
+      participant.participant_state === ParticipantState.ACTIVE ||
+      participant.participant_state === ParticipantState.EXPIRED,
   )
+
+  if (!authorized)
     throw new TrustError(
       TrustErrorCode.NOT_AUTHORIZED,
-      `Participant for the specified DID: ${did} for schema ${schemaId} is ${authorized.participant_state ?? 'in an unknown state'}`,
+      `Participant for the specified DID: ${did} for schema ${schemaId} is ${covering[0].participant_state ?? 'in an unknown state'}`,
     )
 
   logger.debug('Participant verified successfully', { did, schemaId })

--- a/src/utils/credentialDigest.ts
+++ b/src/utils/credentialDigest.ts
@@ -20,10 +20,7 @@ const DIGEST_ALGORITHMS: Record<string, string> = {
  * `proof` are both included, then base64 with padding and no algorithm prefix. The algorithm comes
  * from the schema, not the value. See the Verifiable Trust spec, Computing `digestJCS`.
  */
-export function computeCredentialDigestJCS(
-  credential: object,
-  digestAlgorithm: string,
-): string {
+export function computeCredentialDigestJCS(credential: object, digestAlgorithm: string): string {
   const algorithm = DIGEST_ALGORITHMS[String(digestAlgorithm).toLowerCase()]
   if (!algorithm)
     throw new TrustError(

--- a/src/utils/credentialDigest.ts
+++ b/src/utils/credentialDigest.ts
@@ -1,5 +1,3 @@
-import type { W3cVerifiableCredential } from '@credo-ts/core'
-
 import { base64 } from '@scure/base'
 import _canonicalize from 'canonicalize'
 
@@ -23,7 +21,7 @@ const DIGEST_ALGORITHMS: Record<string, string> = {
  * from the schema, not the value. See the Verifiable Trust spec, Computing `digestJCS`.
  */
 export function computeCredentialDigestJCS(
-  credential: W3cVerifiableCredential,
+  credential: object,
   digestAlgorithm: string,
 ): string {
   const algorithm = DIGEST_ALGORITHMS[String(digestAlgorithm).toLowerCase()]

--- a/tests/unit/didValidator.test.ts
+++ b/tests/unit/didValidator.test.ts
@@ -768,6 +768,58 @@ describe('DidValidator', () => {
       expect(servicePresentation?.invalidCredentialIds).toContain('urn:vc:carried-invalid')
     })
 
+    it('prefers an ACTIVE Participant over a revoked one covering the same instant', async () => {
+      vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
+        return mockResolversByDid[did]
+      })
+      fetchMocker.setMockResponses({ ...allowlistMockResponses, ...ALL_ANCHOR_MOCKS })
+
+      const registries = createRegistriesWithAdapter({
+        fetchSchema: async (url: string) => {
+          if (url.includes('12345678')) return JSON.stringify(mockCredentialSchemaSer)
+          if (url.includes('12345671')) return JSON.stringify(mockCredentialSchemaOrg)
+          throw new Error(`Unexpected schema URL in adapter: ${url}`)
+        },
+        // the revoked entry is returned BEFORE the active one, both covering the issuance instant
+        listParticipants: async (_schemaId: number, _did: string, role: ParticipantRole) =>
+          role === ParticipantRole.ISSUER
+            ? [
+                {
+                  id: 4,
+                  role: ParticipantRole.ISSUER,
+                  created: '2000-01-01T00:00:00Z',
+                  effective_from: '2000-01-01T00:00:00Z',
+                  participant_state: ParticipantState.REVOKED,
+                },
+                {
+                  id: 45,
+                  role: ParticipantRole.ISSUER,
+                  created: '2000-01-01T00:00:00Z',
+                  effective_from: '2000-01-01T00:00:00Z',
+                  participant_state: ParticipantState.ACTIVE,
+                },
+              ]
+            : [],
+        fetchDigest: async () => ({ created: ANCHORED_AT }),
+        fetchCredentialSchema: async () => ({
+          id: 1,
+          ecosystemId: 1,
+          ecosystemDid: 'did:example:ecosystem',
+          digestAlgorithm: 'sha384',
+          jsonSchema: '',
+        }),
+      })
+
+      const result = await resolveDID(didSelfIssued, {
+        verifiablePublicRegistries: registries,
+        skipDigestSRICheck: true,
+      })
+
+      // the active entry authorises the issuance even though the revoked one is listed first
+      expect(result.verified).toBe(true)
+      expect(result.service?.issuerParticipant?.id).toBe(45)
+    })
+
     it('takes expiresAtTime from the HOLDER entries anchoring the credential', async () => {
       vi.spyOn(Resolver.prototype, 'resolve').mockImplementation(async (did: string) => {
         return mockResolversByDid[did]


### PR DESCRIPTION
`verifyAuthorization` took the **first** Participant matching role + grant window
and checked its state afterward. Now it selects, among all entries covering the
issuance instant, the one in a usable state (ACTIVE/EXPIRED) — instead of relying
on array order.

Per [IDX-VT-EVAL-1]: grant window at the issuance instant, participant_state at
the evaluated block. Order-independent; both error messages preserved.

Adds a regression test where the active entry is not first in the list.
