### PR TITLE
fix: reject non-JSON-LD input in computeCredentialDigestJCS instead of anchoring an unreproducible digest

### DIFF
--- a/src/utils/credentialDigest.ts
+++ b/src/utils/credentialDigest.ts
@@ -19,8 +19,19 @@ const DIGEST_ALGORITHMS: Record<string, string> = {
  * JCS (RFC 8785) over the credential as issued, in its entirety: no member is removed, `id` and
  * `proof` are both included, then base64 with padding and no algorithm prefix. The algorithm comes
  * from the schema, not the value. See the Verifiable Trust spec, Computing `digestJCS`.
+ *
+ * The input MUST be the credential as plain JSON-LD (the shape a verifier fetches over HTTP), not a
+ * VC library's internal class instance. A raw class instance canonicalizes under its internal
+ * property names (e.g. `context` instead of `@context`) and hashes to a digest no third party can
+ * reproduce; serialize it first (e.g. credo-ts `JsonTransformer.toJSON(credential)`).
  */
 export function computeCredentialDigestJCS(credential: object, digestAlgorithm: string): string {
+  if (typeof credential !== 'object' || credential === null || !('@context' in credential))
+    throw new TrustError(
+      TrustErrorCode.INVALID,
+      'computeCredentialDigestJCS expects a plain JSON-LD credential (with `@context`), not a VC library class instance',
+    )
+
   const algorithm = DIGEST_ALGORITHMS[String(digestAlgorithm).toLowerCase()]
   if (!algorithm)
     throw new TrustError(

--- a/tests/unit/credentialDigest.test.ts
+++ b/tests/unit/credentialDigest.test.ts
@@ -43,4 +43,18 @@ describe('computeCredentialDigestJCS', () => {
       }),
     )
   })
+
+  it('rejects a class-instance shape (`context` instead of `@context`) instead of anchoring an unreproducible digest', () => {
+    const classInstance = {
+      context: ['https://www.w3.org/2018/credentials/v1'],
+      id: 'urn:uuid:vtc-1',
+      type: ['VerifiableCredential', 'VerifiableTrustCredential'],
+      issuer: 'did:webvh:example',
+    } as never
+    expect(() => computeCredentialDigestJCS(classInstance, 'sha384')).toThrowError(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ errorCode: TrustErrorCode.INVALID }),
+      }),
+    )
+  })
 })


### PR DESCRIPTION
`computeCredentialDigestJCS` canonicalized any object shape, so a VC library class instance (`context` instead of `@context`) hashed to a digest no third party could reproduce -> `NO_ANCHORED_DIGEST` (seen live on devnet).

Since W3C VCDM MUST include `@context` in JSON-LD form (1.1 and 2.0), the function now rejects inputs without it (`TrustError(INVALID)`) before canonicalizing; a spec-backed guard that catches the footgun without rejecting any valid credential.